### PR TITLE
Refactoring into smaller methods and misc cleanup

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -3,7 +3,6 @@ package com.onesignal.androidsdk
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.DependencyResolveDetails
-import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.VersionInfo
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
@@ -22,18 +21,6 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionR
 // References
 // - Source of Android Gradle Plugin (com.android.application)
 //   https://android.googlesource.com/platform/tools/build/+/oreo-release/gradle/src/main/groovy/com/android/build/gradle/BasePlugin.groovy
-
-class InternalUtils {
-    // standard deep copy implementation
-    static Object deepcopy(orig) {
-        def bos = new ByteArrayOutputStream()
-        def oos = new ObjectOutputStream(bos)
-        oos.writeObject(orig); oos.flush()
-        def bin = new ByteArrayInputStream(bos.toByteArray())
-        def ois = new ObjectInputStream(bin)
-        return ois.readObject()
-    }
-}
 
 class GradleProjectPlugin implements Plugin<Project> {
 
@@ -71,21 +58,14 @@ class GradleProjectPlugin implements Plugin<Project> {
         versionGroupAligns = InternalUtils.deepcopy(VERSION_GROUP_ALIGNS)
 
         project.configurations.all { configuration ->
-
             project.afterEvaluate {
                 generateHighestVersionsForGroups(configuration)
                 doResolutionStrategy(configuration)
             }
 
-            // Android Specific task
-            // This allows aligning of <buildType>CompileClasspath tasks
+            // Catches Android specific tasks, <buildType>CompileClasspath
             project.dependencies {
                 generateHighestVersionsForGroups(configuration)
-
-                // ConfigurationInternal.InternalState.ARTIFACTS_RESOLVED
-                if (configuration.getResolvedState() == 2)
-                    return
-
                 doResolutionStrategy(configuration)
             }
         }
@@ -93,37 +73,40 @@ class GradleProjectPlugin implements Plugin<Project> {
 
     static void doResolutionStrategy(Object configuration) {
         configuration.resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            if (!isInGroupAlignList(details))
+            if (!inGroupAlignList(details))
                 return
 
             def toVersion = finalAlignmentRules()[details.requested.group]['version']
-            overrideVersion(project, details, toVersion)
+            overrideVersion(details, toVersion)
         }
     }
 
     static void compileSdkVersionAlign(Project project, def versionOverride) {
         if (!versionOverride['compileSdkVersionAlign'])
-            return;
+            return
 
-        def curCompileSdkVersion = project.android.compileSdkVersion.split('-')[1].toInteger()
-        def firstPartVersion = versionOverride['version'].split('\\.').first().toInteger();
-        if (curCompileSdkVersion < firstPartVersion)
-            versionOverride['version'] = "${curCompileSdkVersion}.+"
+        def compileSdkVersion = project.android.compileSdkVersion.split('-')[1].toInteger()
+        def libraryGroupVersion = versionOverride['version'].split('\\.').first().toInteger()
+        if (compileSdkVersion < libraryGroupVersion)
+            versionOverride['version'] = "${compileSdkVersion}.+"
     }
 
-    static void overrideVersion(Project project, DependencyResolveDetails details, String resolvedVersion) {
+    static void overrideVersion(DependencyResolveDetails details, String resolvedVersion) {
         if (resolvedVersion == '0.0.0')
             return
 
         details.useVersion(resolvedVersion)
+        logModuleOverride(details, resolvedVersion)
+    }
 
+    static void logModuleOverride(DependencyResolveDetails details, String resolvedVersion) {
         def modName = "${details.requested.group}:${details.requested.name}"
         def versionsMsg = "'${details.requested.version}' to '${resolvedVersion}'"
         def msg = "${modName} overridden from ${versionsMsg}"
-        project.logger.warn("OneSignalProjectPlugin: ${msg}");
+        project.logger.warn("OneSignalProjectPlugin: ${msg}")
     }
 
-    static boolean isInGroupAlignList(def details) {
+    static boolean inGroupAlignList(def details) {
         // Only override groups we define
         def versionOverride = versionGroupAligns[details.requested.group]
         if (!versionOverride)
@@ -146,99 +129,114 @@ class GradleProjectPlugin implements Plugin<Project> {
     }
 
     static Object finalAlignmentRules() {
-        project.logger.debug("OneSignalProjectPlugin: FINAL PART 1: ${versionGroupAligns}")
+        project.logger.debug("OneSignalProjectPlugin: FINAL ALIGN PART 1: ${versionGroupAligns}")
 
         def finalVersionGroupAligns = InternalUtils.deepcopy(versionGroupAligns)
-        alignAcrossGroups(finalVersionGroupAligns);
-        updateMockVersionsIntoGradleVersions(finalVersionGroupAligns);
+        alignAcrossGroups(finalVersionGroupAligns)
+        updateMockVersionsIntoGradleVersions(finalVersionGroupAligns)
 
-        project.logger.debug("OneSignalProjectPlugin: FINAL PART 2: ${finalVersionGroupAligns}")
+        project.logger.debug("OneSignalProjectPlugin: FINAL ALIGN PART 2: ${finalVersionGroupAligns}")
         return finalVersionGroupAligns
     }
 
-    static void alignAcrossGroups(def finalVersionGroupAligns) {
+    static void alignAcrossGroups(def versionGroupAligns) {
         def highestVersion = getHighestVersion(
-            finalVersionGroupAligns['com.google.android.gms']['version'],
-            finalVersionGroupAligns['com.google.firebase']['version']
+            versionGroupAligns['com.google.android.gms']['version'],
+            versionGroupAligns['com.google.firebase']['version']
         )
 
-        finalVersionGroupAligns['com.google.android.gms']['version'] = highestVersion
-        finalVersionGroupAligns['com.google.firebase']['version'] = highestVersion
+        versionGroupAligns['com.google.android.gms']['version'] = highestVersion
+        versionGroupAligns['com.google.firebase']['version'] = highestVersion
     }
 
     static void updateMockVersionsIntoGradleVersions(def finalVersionGroupAligns) {
         finalVersionGroupAligns.each { group ->
             compileSdkVersionAlign(project, group.value)
 
-            // Mock latest into Gradle latest
-            if (group.value['version'] == '9999.9999.9999')
-                group.value['version'] = '+'
+            String version = group.value['version']
 
-            group.value['version'] = group.value['version'].replace('9999', '+')
-            // TODO: This shouldn't be needed.
-            //   This is an indication of extra unneeded calls to generateHighestVersionsForGroups
-            group.value['version'] = group.value['version'].replace(".+.+", ".+")
+            // Mock latest into Gradle latest
+            if (version == '9999.9999.9999')
+                version = '+'
+
+            group.value['version'] = version.replace('9999', '+').replace(".+.+", ".+")
         }
     }
 
     static void generateHighestVersionsForGroups(def configuration) {
-        if (configuration.name.endsWith('Copy'))
-            return
-
         def configCopy = configuration.copy()
-        // Gradle 2.14.1 check
+        // canBeResolved not available on Gradle 2.14.1 and older
         if (configCopy.hasProperty('canBeResolved'))
             configCopy.canBeResolved = true
 
         configCopy.resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            if (!isInGroupAlignList(details))
+            if (!inGroupAlignList(details))
                 return
 
-            def defaultVersionComparator = new DefaultVersionComparator()
-            def defaultVersionSelectorScheme  = new DefaultVersionSelectorScheme(defaultVersionComparator)
-            def parsedVersion = defaultVersionSelectorScheme.parseSelector(details.requested.version)
-
-            def highVersion = null
-            if (parsedVersion instanceof ExactVersionSelector)
-                highVersion = details.requested.version
-            else if (parsedVersion instanceof VersionRangeSelector) {
-                if (parsedVersion.upperInclusive)
-                    highVersion = parsedVersion.upperBound
-                else {
-                    def parts = parsedVersion.upperBound.split('\\.')
-                    if (parts.last() != '0') {
-                        def lastDigit = parts.last().toInteger() - 1
-                        parts[parts.size() - 1] = lastDigit.toString()
-                    }
-                    else {
-                        def secondToLastDigit = parts[parts.size() - 2].toInteger() - 1
-                        if (secondToLastDigit == -1) {
-                            def firstDigit = parts.first().toInteger() - 1
-                            parts[0] = firstDigit.toString()
-                            parts[1] = '9999'
-                        }
-                        else
-                            parts[parts.size() - 2] = secondToLastDigit.toString()
-                        parts[parts.size() - 1] = '9999'
-                    }
-                    highVersion = parts.join('.')
-                }
-            }
-            else if (parsedVersion instanceof SubVersionSelector)
-                highVersion = details.requested.version.replace('+', '9999')
-            else if (parsedVersion instanceof LatestVersionSelector)
-                highVersion = '9999.9999.9999'
-            else
-                project.logger.error("OneSignalProjectPlugin: Unkown VersionSelector: ${VersionSelector}")
-
             def curOverrideVersion = versionGroupAligns[details.requested.group]['version']
-            def compareVersionResult = compareVersions(highVersion, curOverrideVersion)
+            def inComingVersion = getVersionFromDependencyResolveDetails(details)
+
+            def compareVersionResult = compareVersions(inComingVersion, curOverrideVersion)
             if (compareVersionResult > 0)
-                versionGroupAligns[details.requested.group]['version'] = highVersion
+                versionGroupAligns[details.requested.group]['version'] = inComingVersion
         }
 
-        // Triggers configCopy.resolutionStrategy.eachDependency
-        ResolvedConfiguration resolvedConfiguration = configCopy.getResolvedConfiguration()
-        resolvedConfiguration.getResolvedArtifacts();
+        triggerResolutionStrategy(configCopy)
+    }
+
+    static void triggerResolutionStrategy(Object configuration) {
+        configuration.resolvedConfiguration.resolvedArtifacts
+    }
+
+    static String getVersionFromDependencyResolveDetails(DependencyResolveDetails details) {
+        def defaultVersionComparator = new DefaultVersionComparator()
+        def defaultVersionSelectorScheme  = new DefaultVersionSelectorScheme(defaultVersionComparator)
+        def parsedVersion = defaultVersionSelectorScheme.parseSelector(details.requested.version)
+
+        if (parsedVersion instanceof ExactVersionSelector)
+            return details.requested.version
+        else if (parsedVersion instanceof VersionRangeSelector)
+            return getHighestVersionFromVersionRangeSelector(parsedVersion)
+        else if (parsedVersion instanceof SubVersionSelector)
+            return details.requested.version.replace('+', '9999')
+        else if (parsedVersion instanceof LatestVersionSelector)
+            return '9999.9999.9999'
+        else
+            project.logger.error("OneSignalProjectPlugin: Unkown VersionSelector: ${parsedVersion}")
+
+        return null
+    }
+
+    static final int MAJOR_INDEX = 0
+    static final int MINOR_INDEX = 1
+    static final int PATCH_INDEX = 2
+
+    static String getHighestVersionFromVersionRangeSelector(VersionRangeSelector parsedVersion) {
+        if (parsedVersion.upperInclusive)
+            return parsedVersion.upperBound
+
+        // If upper limit of range is exclusive subtract 1 from the version
+
+        def parts = parsedVersion.upperBound.split('\\.')
+
+        if (parts[PATCH_INDEX] != '0') {
+            def patchVersion = parts[PATCH_INDEX].toInteger() - 1
+            parts[PATCH_INDEX] = patchVersion.toString()
+        }
+        else {
+            parts[PATCH_INDEX] = '9999'
+
+            def minorVersion = parts[MINOR_INDEX].toInteger() - 1
+            if (minorVersion == -1) {
+                parts[MINOR_INDEX] = '9999'
+
+                def majorVersion = parts[MAJOR_INDEX].toInteger() - 1
+                parts[MAJOR_INDEX] = majorVersion.toString()
+            }
+            else
+                parts[MINOR_INDEX] = minorVersion.toString()
+        }
+
+        return parts.join('.')
     }
 }

--- a/src/main/groovy/com/onesignal/androidsdk/InternalUtils.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/InternalUtils.groovy
@@ -1,0 +1,13 @@
+package com.onesignal.androidsdk
+
+class InternalUtils {
+    // standard deep copy implementation
+    static Object deepcopy(orig) {
+        def bos = new ByteArrayOutputStream()
+        def oos = new ObjectOutputStream(bos)
+        oos.writeObject(orig); oos.flush()
+        def bin = new ByteArrayInputStream(bos.toByteArray())
+        def ois = new ObjectInputStream(bin)
+        return ois.readObject()
+    }
+}

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -1,7 +1,6 @@
 package com.onesignal.androidsdk
 
 import spock.lang.Specification
-import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 
 import org.gradle.testkit.runner.GradleRunner
@@ -197,13 +196,6 @@ class MainTest extends Specification {
 
         then:
         results.each {
-            // TODO: Do we need to update this test? Let see if things changes before then...
-            // Seems to be a 2 step process now:
-//            configCopy.resolutionStrategy.eachDependency: details: org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencyResolveDetails@418858af
-//            OneSignalProjectPlugin: com.android.support:support-v4 overridden from '+' to '25.0.0'
-//            generateHighestVersionsForGroups: compile
-//            configCopy.resolutionStrategy.eachDependency: details: org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DefaultDependencyResolveDetails@2a44975d
-//            OneSignalProjectPlugin: com.android.support:support-v4 overridden from '25.0.0' to '26.+'
             assert it.value.contains('OneSignalProjectPlugin: com.android.support:support-v4 overridden from \'+\' to \'26.+\'')
         }
     }


### PR DESCRIPTION
* Removed unneeded resolved check
* Removed unneeded Copy name check
* Split up generateHighestVersionsForGroups
* Moved InternalUtils into it's own file
* Other misc cleanup

History:
collectedHighestVersion debugging https://github.com/OneSignal/OneSignal-Gradle-Plugin/pull/5/commits/028ec3486d793d0768b4dbbd914f7fc4eff7b370