### PR TITLE
Changed logging to info instead of warn

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -220,6 +220,9 @@ class GradleProjectPlugin implements Plugin<Project> {
         if (resolvedVersion == '0.0.0')
             return
 
+        if (details.requested.version == resolvedVersion)
+            return
+
         details.useVersion(resolvedVersion)
         logModuleOverride(details, resolvedVersion)
     }
@@ -228,7 +231,7 @@ class GradleProjectPlugin implements Plugin<Project> {
         def modName = "${details.requested.group}:${details.requested.name}"
         def versionsMsg = "'${details.requested.version}' to '${resolvedVersion}'"
         def msg = "${modName} overridden from ${versionsMsg}"
-        project.logger.warn("OneSignalProjectPlugin: ${msg}")
+        project.logger.info("OneSignalProjectPlugin: ${msg}")
     }
 
     static boolean inGroupAlignList(def details) {

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -18,13 +18,13 @@ class MainTest extends Specification {
 
     def buildArgumentSets = [
         '2.14.1': [
-            ['dependencies', '--configuration', 'compile'],
-            ['dependencies', '--configuration', '_debugCompile']
+            ['dependencies', '--configuration', 'compile', '--info'],
+            ['dependencies', '--configuration', '_debugCompile', '--info']
         ],
         '4.3': [
             // compile does not work on it's own for tests since we use variant.compileConfiguration
-            ['dependencies', '--configuration', 'compile'],
-            ['dependencies', '--configuration', 'debugCompileClasspath'] //  '--stacktrace'
+            ['dependencies', '--configuration', 'compile', '--info'],
+            ['dependencies', '--configuration', 'debugCompileClasspath', '--info'] //  '--stacktrace'
         ]
     ]
 


### PR DESCRIPTION
* Changed "... overridden from ..." to info instead of warn to hide them by default.
* Prevent log entries if version doesn't change