### PR TITLE
Handle no targetSdkVersion or minSdkVersion

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -163,7 +163,13 @@ class GradleProjectPlugin implements Plugin<Project> {
         def targetSdkVersion = 0
         project.android.applicationVariants.all { variant ->
             def mergedFlavor = variant.getMergedFlavor()
-            targetSdkVersion = mergedFlavor.targetSdkVersion.apiLevel
+            // Use targetSdkVersion unless null, fallback is minSdkVersion, 1 the static fallback
+            if (mergedFlavor.targetSdkVersion != null)
+                targetSdkVersion = mergedFlavor.targetSdkVersion.apiLevel
+            else if ( mergedFlavor.minSdkVersion != null)
+                targetSdkVersion = mergedFlavor.minSdkVersion.apiLevel
+            else
+                targetSdkVersion = 1
         }
 
         targetSdkVersion

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -14,7 +14,8 @@ class GradleTestTemplate {
 
     static def defaultBuildParams = [
         compileSdkVersion: 26,
-        targetSdkVersion: 26
+        targetSdkVersion: 26,
+        minSdkVersion: 15
     ]
 
     static def setup() {
@@ -84,11 +85,12 @@ class GradleTestTemplate {
                  defaultConfig {
                     applicationId 'com.app.example'
 
-                    minSdkVersion 15
-                    targetSdkVersion ${buildSections['targetSdkVersion']}
+                    minSdkVersion ${buildSections['minSdkVersion']}
                     versionCode 1
                     versionName '1.0'
                     multiDexEnabled true
+
+                    ${buildSections['defaultConfigExtras']}
                 }
                 
                 buildTypes {
@@ -125,8 +127,7 @@ class GradleTestTemplate {
                 compileSdkVersion ${buildSections['compileSdkVersion']}
                 buildToolsVersion '26.0.2'
                  defaultConfig {
-                    minSdkVersion 15
-                    targetSdkVersion ${buildSections['targetSdkVersion']}
+                    minSdkVersion ${buildSections['minSdkVersion']}
                 }
                 buildTypes {
                     main { }
@@ -152,6 +153,9 @@ class GradleTestTemplate {
                     testProjectDir.delete()
 
                 def currentParams = defaultBuildParams + buildParams
+
+                if (!buildParams['skipTargetSdkVersion'])
+                  currentParams['defaultConfigExtras'] = "targetSdkVersion ${currentParams['targetSdkVersion']}"
 
                 createBuildFile(currentParams)
                 buildFileStr = buildFileStr.replace('com.android.tools.build:gradle:XX.XX.XX', gradleVersion.value)

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -102,7 +102,7 @@ class MainTest extends Specification {
 
         then:
         results.each {
-            assert it.value.contains('OneSignalProjectPlugin: com.android.support:support-v4 overridden from \'+\' to \'26.+\'')
+            assert it.value.contains('com.android.support:support-v4 overridden from \'+\' to \'26.+\'')
         }
     }
 
@@ -224,6 +224,21 @@ class MainTest extends Specification {
             assert it.value.contains('+--- com.android.support:support-v4:[26.0.0,26.2.0) -> 26.1.0 (*)')
             assert it.value.contains('--- com.android.support:appcompat-v7:25.0.0 -> 26.1.0')
             assert it.value.contains('--- com.android.support:customtabs:[26.0.0,26.2.0) -> 26.1.0')
+        }
+    }
+
+    def "support missing targetSdkVersion"() {
+        // minSdkVersion should be used as a fallback
+        when:
+        def results = runGradleProject([
+            compileLines : "compile 'com.onesignal:OneSignal:3.6.4'",
+            skipTargetSdkVersion: true,
+            minSdkVersion: 26
+        ])
+
+        then:
+        results.each {
+            assert it.value.contains('+--- com.google.android.gms:play-services-gcm:[10.2.1,11.3.0) -> 11.2.2')
         }
     }
 }


### PR DESCRIPTION
* Handles projects that do not include targetSdkVersion
  - Fallback to minSdkVersion, with a fallback of 1 if both are missing
* The above fallback behavior is the same as the AGP
* Fixes #20