### PR TITLE
Version ranges are kept instead of using highest

### DIFF
--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -13,11 +13,24 @@ class MainTest extends Specification {
         GradleTestTemplate.runGradleProject(params)
     }
 
-    def "OneSignal version 3_6_4"() {
-        def compileLines = "compile 'com.onesignal:OneSignal:3.6.4'"
+    // This version range is in the OneSignal instructions
+    def "OneSignal version range test"() {
+        def compileLines = "compile 'com.onesignal:OneSignal:[3.8.3, 3.99.99]'"
 
         when:
         def results = runGradleProject([compileLines : compileLines])
+
+        then:
+        results.each {
+            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.8.3')
+        }
+    }
+
+    def "OneSignal version 3_6_4 With compileSdkVersion 27"() {
+        def compileLines = "compile 'com.onesignal:OneSignal:3.6.4'"
+
+        when:
+        def results = runGradleProject([compileSdkVersion: 27, compileLines : compileLines])
 
         then:
         results.each {
@@ -28,11 +41,114 @@ class MainTest extends Specification {
         }
     }
 
+    def "OneSignal version 3_6_4 with compileSdkVersion 26"() {
+        def compileLines = "compile 'com.onesignal:OneSignal:3.6.4'"
+
+        when:
+        def results = runGradleProject([compileSdkVersion: 26, compileLines : compileLines])
+
+        then:
+        results.each {
+            assert it.value.contains('+--- com.google.android.gms:play-services-gcm:[10.2.1,11.3.0) -> 11.2.2')
+            assert it.value.contains('+--- com.google.android.gms:play-services-location:[10.2.1,11.3.0) -> 11.2.2')
+            assert it.value.contains('+--- com.android.support:support-v4:[26.0.0,26.2.0) -> 26.1.0 (*)')
+            assert it.value.contains('\\--- com.android.support:customtabs:[26.0.0,26.2.0) -> 26.1.0')
+        }
+    }
+
+
+    // OneSignal 3.7.0 had it's dependencies defined as inclusive on both ends
+    //   which caused it to use the highest of the range 11.6.99 which isn't a real version
+    // Testing Issue #14
+    // https://github.com/OneSignal/OneSignal-Gradle-Plugin/issues/14
+    def "OneSignal version 3_7_0"() {
+        def compileLines = "compile 'com.onesignal:OneSignal:3.7.0'"
+
+        when:
+        def results = runGradleProject([compileLines : compileLines])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            assert it.value.contains('com.google.android.gms:play-services-gcm:[10.2.1, 11.6.99] -> 11.6.2')
+            assert it.value.contains('com.google.android.gms:play-services-location:[10.2.1, 11.6.99] -> 11.6.2')
+            assert it.value.contains('com.android.support:support-v4:[26.0.0, 27.0.99] -> 27.0.2')
+            assert it.value.contains('com.android.support:customtabs:[26.0.0, 27.0.99] -> 27.0.2')
+        }
+    }
+
+
+    // Helper to test both directions of inComing and existing versions
+    static assertAcceptedOrIntersectVersion(String inComingStr, String existingStr, String expected) {
+        assert GradleProjectPlugin.acceptedOrIntersectVersion(inComingStr, existingStr) == expected
+        assert GradleProjectPlugin.acceptedOrIntersectVersion(existingStr, inComingStr) == expected
+    }
+
+    def "GradleProjectPlugin version align core tests"() {
+        // NOTE: Must keep given: here for tests to run!
+        given:
+        // # Both Exact Versions test
+        assertAcceptedOrIntersectVersion('1.0.0', '2.0.0', '2.0.0')
+
+        // # Latest & SubVersionSelector
+        assertAcceptedOrIntersectVersion('+', '+', '+')
+        assertAcceptedOrIntersectVersion('1.+', '2.+', '2.+')
+        assertAcceptedOrIntersectVersion('1.0.+', '2.0.+', '2.0.+')
+        assertAcceptedOrIntersectVersion('1.+', '1.0.+', '1.+')
+
+        // # Version Range with Exact versions
+        // ## Between range = Narrowing Lower
+        assertAcceptedOrIntersectVersion('1.5.0', '[1.0.0, 1.99.99]', '[1.5.0, 1.99.99]')
+        // ## Above range = Expand Upper
+        assertAcceptedOrIntersectVersion('3.0.0', '[1.0.0, 1.99.99]', '[1.0.0, 3.0.0]')
+        // ## Below range = Keep range
+        assertAcceptedOrIntersectVersion('0.5.0', '[1.0.0, 1.99.99]', '[1.0.0, 1.99.99]')
+        // ## At range, making upper and lower the same - Exact version
+        assertAcceptedOrIntersectVersion('2.0.0', '[1.0.0, 2.0.0]', '2.0.0')
+
+
+        // # Both Version Ranges Tests
+        // ## Narrowing from both directions
+        assertAcceptedOrIntersectVersion('[1.0.0, 1.99.99]', '[1.5.0, 1.6.0]', '[1.5.0,1.6.0]')
+        // ## Narrowing lower
+        assertAcceptedOrIntersectVersion('[1.0.0, 1.99.99]', '[0.5.0, 1.5.0]', '[1.0.0,1.5.0]')
+        // ## Narrowing upper
+        assertAcceptedOrIntersectVersion('[1.0.0, 1.99.99]', '[1.5.0, 2.5.0]', '[1.5.0,1.99.99]')
+        // ## Ranges miss = Use newer range
+        assertAcceptedOrIntersectVersion('[1.0.0, 1.99.99]', '[3.0.0, 4.0.0]', '[3.0.0, 4.0.0]')
+
+        // # Both Version Ranges - Exclusive
+        // ## Narrowing from both directions
+        assertAcceptedOrIntersectVersion('(1.0.0, 1.99.99)', '[1.5.0, 1.6.0]', '[1.5.0,1.6.0]')
+        assertAcceptedOrIntersectVersion('(1.0.0, 1.99.99)', '(1.5.0, 1.6.0)', ']1.5.0,1.6.0[')
+        assertAcceptedOrIntersectVersion('(1.0.0, 1.99.99)', '[1.5.0, 1.6.0)', '[1.5.0,1.6.0[')
+
+        // # Latest and Version Ranges
+        // ## Plus at range = Replace lower
+        assertAcceptedOrIntersectVersion('1.+', '[1.0.0, 2.99.99)', '[1.+, 2.99.99)')
+        // ## Plus below range = Keep range - Same as Exact
+        assertAcceptedOrIntersectVersion('1.+', '[2.0.0, 2.99.99)', '[2.0.0, 2.99.99)')
+        // ## Plus above range = Expand upper - Same as Exact
+        assertAcceptedOrIntersectVersion('3.0.+', '[1.0.0, 1.99.99)', '[1.0.0, 3.0.+]')
+        // ## Plus in range = Narrow lower - Same as Exact
+        assertAcceptedOrIntersectVersion('1.5.+', '[1.0.0, 1.99.99)', '[1.5.+, 1.99.99)')
+
+
+        assertAcceptedOrIntersectVersion('[26.0.0, 27.1.0)', '25.+', '[26.0.0, 27.1.0)')
+    }
+
+
+      def "GradleProjectPlugin test lowerMaxVersion"() {
+          // Used to
+          given:
+          assert GradleProjectPlugin.lowerMaxVersion("[26.0.0, 27.1.0)", "27.+") == '[26.0.0, 27.1.0)'
+      }
+
     def "Upgrade to compatible OneSignal SDK when targetSdkVersion is 26"() {
         when:
         def results = runGradleProject([
-            compileLines : "compile 'com.onesignal:OneSignal:3.5.+'",
-            skipGradleVersion: '2.14.1'
+                compileLines : "compile 'com.onesignal:OneSignal:3.5.+'",
+                skipGradleVersion: '2.14.1'
         ])
 
         then:
@@ -75,6 +191,23 @@ class MainTest extends Specification {
         then:
         results.each {
             assert it.value.contains('+--- com.android.support:appcompat-v7:25.0.0 -> 26.1.0')
+        }
+    }
+
+    def "OneSignal 3_8_3 with play games"() {
+        def compileLines = """\
+            compile 'com.onesignal:OneSignal:[3.8.3, 3.99.99]'
+            compile 'com.google.android.gms:play-services-games:11.8.0'
+        """
+
+        when:
+        def results = runGradleProject([compileLines: compileLines])
+
+        then:
+        results.each {
+            // TODO: Since we are including 11.8.0 it should be drop to [10.2.1, 11.8.0]????
+            assert it.value.contains('com.google.android.gms:play-services-gcm:[10.2.1, 12.1.0) -> 12.0.1')
+            assert it.value.contains('com.google.android.gms:play-services-games:11.8.0 -> 12.0.1')
         }
     }
 
@@ -125,12 +258,16 @@ class MainTest extends Specification {
 
     def "Aligns when using +'s"() {
         def compileLines = """\
-        compile 'com.android.support:appcompat-v7:25.0.+'
-        compile 'com.android.support:support-v4:25.+'
+            compile 'com.android.support:appcompat-v7:25.0.+'
+            compile 'com.android.support:support-v4:25.+'
         """
 
         when:
-        def results = runGradleProject([compileLines: compileLines])
+        // Don't increase 'com.android.support' even if compileSdkVersion is newer
+        def results = runGradleProject([
+            compileLines: compileLines,
+            compileSdkVersion: 26
+        ])
 
         then:
         results.each {
@@ -146,12 +283,15 @@ class MainTest extends Specification {
         """
 
         when:
-        def results = runGradleProject([compileLines: compileLines])
+        def results = runGradleProject([
+            compileLines: compileLines,
+            compileSdkVersion: 26
+        ])
 
         then:
         results.each {
-            assert it.value.contains('+--- com.android.support:appcompat-v7:[25.0.0, 26.0.0) -> 26.0.0-beta2')
-            assert it.value.contains('--- com.android.support:support-v4:25.+ -> 26.0.0-beta2 (*)')
+            assert it.value.contains('com.android.support:appcompat-v7:[25.0.0, 26.0.0) -> 26.0.0-beta2')
+            assert it.value.contains('com.android.support:support-v4:25.+ -> 26.0.0-beta2')
         }
     }
 
@@ -175,10 +315,10 @@ class MainTest extends Specification {
 
     def "Test with sub project"() {
         def compileLines = """\
-        compile 'com.onesignal:OneSignal:3.6.4'
-        compile 'com.android.support:appcompat-v7:25.0.0'
-        compile 'com.android.support:support-v4:26.0.0'
-        compile(project(path: "subProject"))
+            compile 'com.onesignal:OneSignal:3.6.4'
+            compile 'com.android.support:appcompat-v7:25.0.0'
+            compile 'com.android.support:support-v4:26.0.0'
+            compile(project(path: 'subProject'))
         """
 
         when:
@@ -199,6 +339,7 @@ class MainTest extends Specification {
         }
     }
 
+    // Need to add compat code for older gradle version.
     def "Ensure flavors work on Gradle 3_3 and latest"() {
         GradleTestTemplate.gradleVersions['3.3'] = 'com.android.tools.build:gradle:2.3.3'
 
@@ -245,7 +386,7 @@ class MainTest extends Specification {
     }
 
     def "support missing targetSdkVersion"() {
-        // minSdkVersion should be used as a fallback
+        // Testing that minSdkVersion is used as a fallback
         when:
         def results = runGradleProject([
             compileLines : "compile 'com.onesignal:OneSignal:3.6.4'",
@@ -259,13 +400,13 @@ class MainTest extends Specification {
         }
     }
 
-    def "support library projects"() {
+    def "support sub library projects"() {
         when:
         def results = runGradleProject([
             skipGradleVersion: '2.14.1',
             compileLines : "compile 'com.onesignal:OneSignal:3.6.4'",
             subProjectCompileLines: """\
-                compile 'com.android.support:cardview-v7:[25.0.0, 26.0.0)'
+                compile 'com.android.support:cardview-v7:[26.0.0, 27.1.0)'
                 compile 'com.android.support:support-v4:25.+'
             """,
             libProjectExtras: "apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'"
@@ -273,14 +414,14 @@ class MainTest extends Specification {
 
         then:
         results.each {
-            assert it.value.contains('+--- com.android.support:cardview-v7:[25.0.0, 26.0.0) -> 26.0.0-beta2')
-            assert it.value.contains('--- com.android.support:support-v4:25.+ -> 26.0.0-beta2')
+            assert it.value.contains('com.android.support:cardview-v7:[26.0.0, 27.1.0) -> 27.0.2')
+            assert it.value.contains('com.android.support:support-v4:25.+ -> 27.0.2 (*)')
         }
     }
 
     def "Upgrade to compatible OneSignal SDK when targetSdkVersion is 26 with build tasks"() {
         GradleTestTemplate.buildArgumentSets['4.6'] = [
-            ['build', '--info'],
+            ['build', '--info']
         ]
 
         when:
@@ -293,7 +434,7 @@ class MainTest extends Specification {
         assert results // Asserting existence and contains 1+ entries
         results.each {
             assert it.value.contains("com.onesignal:OneSignal overridden from '3.5.+' to '3.6.3'")
-            assert it.value.contains("com.google.android.gms:play-services-gcm overridden from '[10.2.1,11.3.0)' to '11.2.+'")
+            assert it.value.contains("com.android.support:support-v4 overridden from '25.2.0' to '[26.1.0,26.2.0['")
         }
     }
 }


### PR DESCRIPTION
* This was done by using Gradle's VersionRangeSelector class along with it's intersect and accept methods
   - This was added in gradle 4.3
   - This plugin still supports 2.14.1 so this class source might need to be pulled in
* If an exact version fits in a range the bottom of the range will be bumped to it
   - If version is lower it will be ignored
* Intersect works as expected, a common range of 2 version ranges will be used
   - If there is no intersect the high range will be used
* Now gets new version dependencies of com.onesignal if it is upgraded
* This also fixes #14
   - Where Dependencies ending with inclusive version ranges would pick non-existent versions