### PR TITLE
Pin exact version when in range instead of changing bounds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        maven { url 'https://maven.google.com' }
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
-    }
-}
-
 plugins {
     id 'com.gradle.plugin-publish' version '0.9.10'
     id 'java-gradle-plugin'
@@ -19,12 +10,14 @@ repositories {
 
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
+apply plugin: 'java-library'
 
 dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile 'com.android.tools.build:gradle:3.1.0'
+    compileOnly 'com.android.tools.build:gradle:3.1.0'
+    testCompileOnly 'com.android.tools.build:gradle:3.1.0'
 
     testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        maven { url 'https://maven.google.com' }
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.1.0'
+    }
+}
+
 plugins {
     id 'com.gradle.plugin-publish' version '0.9.10'
     id 'java-gradle-plugin'
@@ -5,6 +14,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url 'https://maven.google.com' }
 }
 
 apply plugin: 'groovy'
@@ -13,6 +23,8 @@ apply plugin: 'java-gradle-plugin'
 dependencies {
     compile gradleApi()
     compile localGroovy()
+
+    compile 'com.android.tools.build:gradle:3.1.0'
 
     testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'
@@ -42,8 +54,6 @@ pluginBundle {
 }
 
 gradlePlugin {
-    pluginSourceSet project.sourceSets.main
-    testSourceSets project.sourceSets.test
     plugins {
         plugin {
             id = 'com.onesignal.androidsdk.onesignal-gradle-plugin'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Apr 07 01:18:05 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -122,9 +122,6 @@ class GradleProjectPlugin implements Plugin<Project> {
 
     static boolean didUpdateOneSignalVersion
 
-    // TODO: MUSTS BEFORE next release 0.8.3+
-    //   TODO: 1. Compat for VersionRangeSelector.intersect for Gradle 2.14.1 to 4.2
-    //   TODO: 2. Ensure VersionRangeSelector.accept works
     @Override
     void apply(Project inProject) {
         project = inProject

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -500,10 +500,20 @@ class GradleProjectPlugin implements Plugin<Project> {
         versionSelector
     }
 
+
+    // VersionRangeSelector.intersect was introduced in Gradle 4.3, this is a compat wrapper method
+    static VersionRangeSelector intersectCompat(VersionRangeSelector inComing, VersionRangeSelector existing) {
+        if (inComing.metaClass.respondsTo(inComing, 'intersect', VersionRangeSelector, VersionRangeSelector))
+            return inComing.intersect(existing)
+
+        // This means we are on Gradle 4.2 or older so use compat version of intersect
+        VersionCompatHelpers.intersect(inComing, existing)
+    }
+
     // Returns the intersection range of two versions
     // If no over lap the higher of the two will be returned
     static VersionRangeSelector mergedIntersectOrHigher(VersionRangeSelector inComing, VersionRangeSelector existing) {
-        def intersectResult = inComing.intersect(existing)
+        def intersectResult = intersectCompat(inComing, existing)
         if (intersectResult != null)
             return intersectResult
 

--- a/src/main/groovy/com/onesignal/androidsdk/VersionCompatHelpers.java
+++ b/src/main/groovy/com/onesignal/androidsdk/VersionCompatHelpers.java
@@ -1,0 +1,222 @@
+// This file contains source code from Gradle
+// Copyright from source VersionRangeSelector.java attached below
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This exists to use newer Gradle features back to Gradle version 2.14.1
+// Source from the following URL
+// https://github.com/gradle/gradle/blob/v4.6.0/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionRangeSelector.java
+
+package com.onesignal.androidsdk;
+
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector;
+
+import java.lang.reflect.Field;
+import java.util.Comparator;
+import java.util.regex.Pattern;
+
+public class VersionCompatHelpers {
+
+    private static final String OPEN_INC = "[";
+
+    private static final String OPEN_EXC = "]";
+    private static final String OPEN_EXC_MAVEN = "(";
+
+    private static final String CLOSE_INC = "]";
+
+    private static final String CLOSE_EXC = "[";
+    private static final String CLOSE_EXC_MAVEN = ")";
+
+    private static final String LOWER_INFINITE = "(";
+
+    private static final String UPPER_INFINITE = ")";
+
+    private static final String SEPARATOR = ",";
+
+    // following patterns are built upon constants above and should not be modified
+    private static final String OPEN_INC_PATTERN = "\\" + OPEN_INC;
+
+    private static final String OPEN_EXC_PATTERN = "\\" + OPEN_EXC + "\\" + OPEN_EXC_MAVEN;
+
+    private static final String CLOSE_INC_PATTERN = "\\" + CLOSE_INC;
+
+    private static final String CLOSE_EXC_PATTERN = "\\" + CLOSE_EXC + "\\" + CLOSE_EXC_MAVEN;
+
+    private static final String LI_PATTERN = "\\" + LOWER_INFINITE;
+
+    private static final String UI_PATTERN = "\\" + UPPER_INFINITE;
+
+    private static final String SEP_PATTERN = "\\s*\\" + SEPARATOR + "\\s*";
+
+    private static final String OPEN_PATTERN = "[" + OPEN_INC_PATTERN + OPEN_EXC_PATTERN + "]";
+
+    private static final String CLOSE_PATTERN = "[" + CLOSE_INC_PATTERN + CLOSE_EXC_PATTERN + "]";
+
+    private static final String ANY_NON_SPECIAL_PATTERN = "[^\\s" + SEPARATOR + OPEN_INC_PATTERN
+            + OPEN_EXC_PATTERN + CLOSE_INC_PATTERN + CLOSE_EXC_PATTERN + LI_PATTERN + UI_PATTERN
+            + "]";
+
+    private static final String FINITE_PATTERN = OPEN_PATTERN + "\\s*(" + ANY_NON_SPECIAL_PATTERN
+            + "+)" + SEP_PATTERN + "(" + ANY_NON_SPECIAL_PATTERN + "+)\\s*" + CLOSE_PATTERN;
+
+    private static final String LOWER_INFINITE_PATTERN = LI_PATTERN + SEP_PATTERN + "("
+            + ANY_NON_SPECIAL_PATTERN + "+)\\s*" + CLOSE_PATTERN;
+
+    private static final String UPPER_INFINITE_PATTERN = OPEN_PATTERN + "\\s*("
+            + ANY_NON_SPECIAL_PATTERN + "+)" + SEP_PATTERN + UI_PATTERN;
+
+    private static final String SINGLE_VALUE_PATTERN = OPEN_INC_PATTERN + "\\s*(" + ANY_NON_SPECIAL_PATTERN + "+)" + CLOSE_INC_PATTERN;
+
+    private static final Pattern FINITE_RANGE = Pattern.compile(FINITE_PATTERN);
+
+    private static final Pattern LOWER_INFINITE_RANGE = Pattern.compile(LOWER_INFINITE_PATTERN);
+
+    private static final Pattern UPPER_INFINITE_RANGE = Pattern.compile(UPPER_INFINITE_PATTERN);
+
+    private static final Pattern SINGLE_VALUE_RANGE = Pattern.compile(SINGLE_VALUE_PATTERN);
+
+    public static final Pattern ALL_RANGE = Pattern.compile(FINITE_PATTERN + "|"
+            + LOWER_INFINITE_PATTERN + "|" + UPPER_INFINITE_PATTERN + "|" + SINGLE_VALUE_RANGE);
+
+
+    // Source from Gradle 4.6 VersionRangeSelector.intersect
+    static public VersionRangeSelector intersect(VersionRangeSelector thisVersion, VersionRangeSelector other) {
+        StringBuilder sb = new StringBuilder();
+        Version lower = null;
+        Version upper = null;
+        boolean lowerInc = false;
+        if (getLowerBound(thisVersion) == null) {
+            if (getLowerBound(other) == null) {
+                sb.append(LOWER_INFINITE);
+            } else {
+                sb.append(isLowerInclusive(other) ? OPEN_INC : OPEN_EXC);
+                sb.append(getLowerBound(other));
+                lower = getLowerBoundVersion(other);
+                lowerInc = isLowerInclusive(other);
+            }
+        } else {
+            if (getLowerBound(other) == null || isHigher(getLowerBoundVersion(thisVersion), getLowerBoundVersion(other), isLowerInclusive(thisVersion))) {
+                lowerInc = getLowerBound(thisVersion).equals(getLowerBound(other)) ? isLowerInclusive(thisVersion) && isLowerInclusive(other) : isLowerInclusive(thisVersion);
+                sb.append(lowerInc ? OPEN_INC : OPEN_EXC);
+                sb.append(getLowerBound(thisVersion));
+                lower = getLowerBoundVersion(thisVersion);
+            } else {
+                lowerInc = getLowerBound(other).equals(getLowerBound(thisVersion)) ? isLowerInclusive(thisVersion) && isLowerInclusive(other) : isLowerInclusive(other);
+                sb.append(lowerInc ? OPEN_INC : OPEN_EXC);
+                sb.append(getLowerBound(other));
+                lower = getLowerBoundVersion(other);
+                lowerInc = isLowerInclusive(other);
+            }
+        }
+        sb.append(SEPARATOR);
+        if (getUpperBound(thisVersion) == null) {
+            if (getUpperBound(other) == null) {
+                sb.append(UPPER_INFINITE);
+            } else {
+                sb.append(getUpperBound(other));
+                sb.append(isUpperInclusive(other) ? CLOSE_INC : CLOSE_EXC);
+                upper = getUpperBoundVersion(other);
+            }
+        } else {
+            if (getUpperBound(other) == null || isLower(getUpperBoundVersion(thisVersion), getUpperBoundVersion(other), isUpperInclusive(thisVersion))) {
+                sb.append(getUpperBound(thisVersion));
+                boolean inclusive = getUpperBound(thisVersion).equals(getUpperBound(other)) ? isUpperInclusive(thisVersion) && isUpperInclusive(other) : isUpperInclusive(thisVersion);
+                sb.append(inclusive ? CLOSE_INC : CLOSE_EXC);
+                upper = getUpperBoundVersion(thisVersion);
+            } else {
+                sb.append(getUpperBound(other));
+                boolean inclusive = getUpperBound(other).equals(getUpperBound(thisVersion)) ? isUpperInclusive(thisVersion) && isUpperInclusive(other) : isUpperInclusive(other);
+                sb.append(inclusive ? CLOSE_INC : CLOSE_EXC);
+                upper = getUpperBoundVersion(other);
+            }
+        }
+
+        if (lower != null && upper != null && isHigher(lower, upper, lowerInc)) {
+            return null;
+        }
+        if (lower != null && lower.equals(upper) && !lowerInc) {
+            return null;
+        }
+
+        return new VersionRangeSelector(sb.toString(), getComparator());
+    }
+
+
+    /**
+     * Tells if version1 is lower than version2.
+     */
+    static private boolean isLower(Version version1, Version version2, boolean inclusive) {
+        int result = getComparator().compare(version1, version2);
+        return result <= (inclusive ? 0 : -1);
+    }
+
+    /**
+     * Tells if version1 is higher than version2.
+     */
+    static private boolean isHigher(Version version1, Version version2, boolean inclusive) {
+        int result = getComparator().compare(version1, version2);
+        return result >= (inclusive ? 0 : 1);
+    }
+
+    static private Comparator<Version> getComparator() {
+        return new DefaultVersionComparator().asVersionComparator();
+    }
+
+
+
+    // Using reflection to access private fields on VersionRangeSelector that did not have public methods
+    //   back on Gradle 2.14.1
+    static private Object get(VersionRangeSelector version, String fieldName) {
+        try {
+            Field field = VersionRangeSelector.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(version);
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+        return null;
+    }
+
+    static private String getLowerBound(VersionRangeSelector version) {
+        return (String)get(version, "lowerBound");
+    }
+
+    static private String getUpperBound(VersionRangeSelector version) {
+        return (String)get(version, "upperBound");
+    }
+
+    static private Version getLowerBoundVersion(VersionRangeSelector version) {
+        String lowerBound = getLowerBound(version);
+        return lowerBound == null ? null : new VersionParser().transform(lowerBound);
+    }
+
+    static private Version getUpperBoundVersion(VersionRangeSelector version) {
+        String upperBound = getUpperBound(version);
+        return upperBound == null ? null : new VersionParser().transform(upperBound);
+    }
+
+    static private boolean isLowerInclusive(VersionRangeSelector version) {
+        return (Boolean)get(version, "lowerInclusive");
+    }
+
+    static private boolean isUpperInclusive(VersionRangeSelector version) {
+        return (Boolean)get(version, "upperInclusive");
+    }
+
+}

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -107,7 +107,7 @@ class GradleTestTemplate {
 
                 ${
                 if (buildSections['subProjectCompileLines'] != null)
-                   "implementation(project(':subProject'))"
+                   "compile(project(':subProject'))"
                 else
                     ''
                 }

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -107,7 +107,7 @@ class GradleTestTemplate {
 
                 ${
                 if (buildSections['subProjectCompileLines'] != null)
-                   "compile(project(':subProject'))"
+                   "implementation(project(':subProject'))"
                 else
                     ''
                 }
@@ -140,7 +140,6 @@ class GradleTestTemplate {
                     minSdkVersion ${buildSections['minSdkVersion']}
                 }
                 buildTypes {
-                    main { }
                     debug { }
                 }
             }

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -96,7 +96,6 @@ class MainTest extends Specification {
 
     def "GMS pining when in version range - OneSignal in sub project"() {
         def compileLines = """\
-            compile(project(path: 'subProject'))
             compile 'com.google.android.gms:play-services-base:11.4.0'
         """
 
@@ -115,7 +114,6 @@ class MainTest extends Specification {
 
     def "GMS pining when in version range - GMS in sub project - Gradle 2_14_1"() {
         def compileLines = """\
-            compile(project(path: 'subProject'))
             compile 'com.onesignal:OneSignal:3.8.3'
         """
 
@@ -133,10 +131,6 @@ class MainTest extends Specification {
         }
     }
 
-    // TODO: This test asserts an expected acceptable outcome, the best outcome is noted below
-    //       It would great to this pining working as this is going to be a common case
-    //       If anther SDK pins GMS to a specific version that is also in the
-    //          OneSignal SDK's range it should be respected for best chance of compatibility
     def "GMS pining when in version range - GMS in sub project - Gradle 4_6"() {
         def compileLines = """\
             compile 'com.onesignal:OneSignal:3.8.3'
@@ -152,7 +146,6 @@ class MainTest extends Specification {
         then:
         assert results // Asserting existence and contains 1+ entries
         results.each {
-            // NOTE: This assert is the known behavior but should be "-> 11.4.0" instead
             assert it.value.contains('com.google.android.gms:play-services-gcm:[10.2.1, 12.1.0) -> 11.4.0')
         }
     }
@@ -254,7 +247,7 @@ class MainTest extends Specification {
     def "Upgrade to compatible OneSignal SDK when targetSdkVersion is 26"() {
         when:
         def results = runGradleProject([
-            compileSdkVersion: 26, // Unexpected crash if this is 27...
+            compileSdkVersion: 26,
             compileLines : "compile 'com.onesignal:OneSignal:3.5.+'",
             skipGradleVersion: '2.14.1' // This check requires AGP 3.0.1+ which requires Gradle 4.1+
         ])
@@ -427,7 +420,6 @@ class MainTest extends Specification {
             compile 'com.onesignal:OneSignal:3.6.4'
             compile 'com.android.support:appcompat-v7:25.0.0'
             compile 'com.android.support:support-v4:26.0.0'
-            compile(project(path: 'subProject'))
         """
 
         when:
@@ -448,9 +440,7 @@ class MainTest extends Specification {
         }
     }
 
-    // Need to add compat code for older gradle version.
     def "Ensure flavors work on Gradle 3_3 and latest"() {
-        // TODO: Need to fix Gradle 3.3 part of this test. Need to implement interest compat yet
         GradleTestTemplate.gradleVersions['3.3'] = 'com.android.tools.build:gradle:2.3.3'
 
         GradleTestTemplate.buildArgumentSets.remove('2.14.1')
@@ -540,7 +530,9 @@ class MainTest extends Specification {
 
         when:
         def results = runGradleProject([
-            compileLines : "compile 'com.onesignal:OneSignal:3.5.+'",
+            compileSdkVersion: 26,
+            targetSdkVersion: 26,
+            compileLines: "compile 'com.onesignal:OneSignal:3.5.+'",
             skipGradleVersion: '2.14.1'
         ])
 
@@ -548,9 +540,9 @@ class MainTest extends Specification {
         assert results // Asserting existence and contains 1+ entries
         results.each {
             assert it.value.contains("com.onesignal:OneSignal overridden from '3.5.+' to '3.6.3'")
-            // 25.2.0 comes from; com.onesignal:OneSignal:3.6.3 ->
-            //                      com.google.android.gms:play-services-basement:[10.2.1,11.3.0) -> 11.2.2 ->
-            //                         com.android.support:25.2.0
+            // 25.2.0 comes from; + com.onesignal:OneSignal:3.6.3 ->
+            //                    |- + com.google.android.gms:play-services-basement:[10.2.1,11.3.0) -> 11.2.2 ->
+            //                    \---- + com.android.support:25.2.0
             assert it.value.contains("com.android.support:support-v4 overridden from '25.2.0' to '[26.0.0,26.2.0['")
         }
     }


### PR DESCRIPTION
* When both an exact version and range are defined pin to exact version if in range instead of changing range bounds
* Example version '1.5.0' and '[1.0.0, 1.99.99]' will result in '1.5.0'
* This does not work in all nested cases yet with gms and android.support for example
   - "GMS pining when in version range - GMS in sub project - Gradle 4_6" test cases is an example of this issue case
* For reference this is to change some of the logic introduced in PR #29 
* Changed `def` to `String` where they could not be inferred to fix Intellij type checks

**History**
Extra debugging dd3324181c2d5dcf391112476102ee70e16436a6