### PR TITLE
Fallback for AGP 2.x when plugin is applied last

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 repositories {
+    jcenter()
     mavenCentral()
     maven { url 'https://maven.google.com' }
 }
@@ -16,8 +17,14 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
+    // These are compileOnly just so we can inspect these classes in IntelliJ
+    // Android Gradle Plugin (AGP)
     compileOnly 'com.android.tools.build:gradle:3.1.2'
     testCompileOnly 'com.android.tools.build:gradle:3.1.2'
+
+    // Google Play Services Gradle Plugin
+    compileOnly 'com.google.gms:google-services:4.0.1'
+    testCompileOnly 'com.google.gms:google-services:4.0.1'
 
     testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -68,8 +68,13 @@ class GradleTestTemplate {
                 }
             }
             
+            // Add local copy of this OneSignal-Gradle-Plugin to test with
             plugins {
-                id 'com.onesignal.androidsdk.onesignal-gradle-plugin'
+                ${buildSections['onesignalPluginId']}
+            }
+            
+            project.ext {
+                 ${buildSections['projectExts']}
             }
             
             allprojects {
@@ -118,6 +123,7 @@ class GradleTestTemplate {
         """\
     }
 
+    // Create subproject only if subProjectCompileLines is set
     static void createSubProject(buildSections) {
         if (buildSections['subProjectCompileLines'] == null)
             return
@@ -169,6 +175,8 @@ class GradleTestTemplate {
                 if (!buildParams['skipTargetSdkVersion'])
                   currentParams['defaultConfigExtras'] = "targetSdkVersion ${currentParams['targetSdkVersion']}"
 
+                applyOneSignalGradlePlugin(currentParams)
+
                 createBuildFile(currentParams)
                 buildFileStr = buildFileStr.replace('com.android.tools.build:gradle:XX.XX.XX', gradleVersion.value)
                 buildFile = testProjectDir.newFile('build.gradle')
@@ -190,5 +198,11 @@ class GradleTestTemplate {
         }
 
         results
+    }
+
+    // Adds plugin OneSignal-Gradle-Plugin above other plugins if no custom definition is set
+    static void applyOneSignalGradlePlugin(buildSections) {
+        if (buildSections['onesignalPluginId'] == null)
+            buildSections['onesignalPluginId'] = "id 'com.onesignal.androidsdk.onesignal-gradle-plugin'"
     }
 }


### PR DESCRIPTION
* If the AGP 2.x plugin is applied before this plugin we can't read the dependency graph
  - We then fallback to some blind safe defaults in this case