### PR TITLE
Fixes google libraries not found on jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 repositories {
+    maven { url 'https://maven.google.com' }
     jcenter()
     mavenCentral()
-    maven { url 'https://maven.google.com' }
 }
 
 apply plugin: 'groovy'

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -59,8 +59,8 @@ class GradleTestTemplate {
         buildFileStr = """\
             buildscript {
                 repositories {
-                      jcenter()
-                      maven { url 'https://maven.google.com' }
+                    maven { url 'https://maven.google.com' }
+                    jcenter()
                 }
                 dependencies {
                     classpath 'com.android.tools.build:gradle:XX.XX.XX'
@@ -79,8 +79,8 @@ class GradleTestTemplate {
             
             allprojects {
                 repositories {
-                    jcenter()
                     maven { url 'https://maven.google.com' }
+                    jcenter()
                 }
             }
 


### PR DESCRIPTION
* jcenter seems to no longer hosting or redirecting google libraries to maven.google.com
* Changed the order of repos to put google first to fix recent build issues