### PR TITLE
Added min Android Support Library version checks for GMS and Firebase

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -114,8 +114,19 @@ class GradleProjectPlugin implements Plugin<Project> {
             ]
         ],
         (GROUP_GMS): [
+            '8.4.0': [
+                (GROUP_ANDROID_SUPPORT): '22.2.1'
+            ],
             '11.2.0': [
                 (GROUP_ANDROID_SUPPORT): '25.1.0'
+            ],
+            '11.8.0': [
+                (GROUP_ANDROID_SUPPORT): '26.0.0'
+            ]
+        ],
+        (GROUP_FIREBASE): [
+            '9.8.0': [
+                (GROUP_ANDROID_SUPPORT): '24.1.0'
             ]
         ]
     ]

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -589,7 +589,6 @@ class GradleProjectPlugin implements Plugin<Project> {
     static void updateParentOnDependencyUpgrade(String dependencyGroup, String dependencyVersion) {
         UPDATE_PARENT_ON_DEPENDENCY_UPGRADE[dependencyGroup].each { key, value ->
             def exactVersion = new ExactVersionSelector(key)
-            project.logger.info("updateParentOnDependencyUpgrade:dependencyGroup: dependencyVersion: $dependencyGroup:$dependencyVersion -> $value:$key = ${isVersionBelow(dependencyVersion, exactVersion)}")
             if (isVersionBelow(dependencyVersion, exactVersion))
                 return // == continue in each closure
 
@@ -601,7 +600,6 @@ class GradleProjectPlugin implements Plugin<Project> {
                         parentGroupVersionEntry['version'] as String
                     )
                     if (compareVersionResult != parentGroupVersionEntry['version']) {
-                        project.logger.info("compareVersionResult: $compareVersionResult != parentGroupVersionEntry['version']: ${parentGroupVersionEntry['version']}")
                         if (parentGroupEntry.key == GROUP_ONESIGNAL)
                             didUpdateOneSignalVersion = true
                         versionGroupAligns[parentGroupEntry.key]['version'] = parentGroupEntry.value

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -564,8 +564,8 @@ class MainTest extends Specification {
         then:
         assert results // Asserting existence and contains 1+ entries
         results.each {
-            assert it.value.contains('com.android.support:cardview-v7:[26.0.0, 27.1.0) -> 27.0.2')
-            assert it.value.contains('com.android.support:support-v4:25.+ -> 27.0.2 (*)')
+            assert it.value.contains('com.android.support:cardview-v7:[26.0.0, 27.1.0) -> 26.1.0')
+            assert it.value.contains('com.android.support:support-v4:25.+ -> 26.1.0')
         }
     }
 
@@ -726,6 +726,24 @@ class MainTest extends Specification {
         assert results // Asserting existence and contains 1+ entries
         results.each {
             assert !it.value.toLowerCase().contains('failure')
+        }
+    }
+    def 'upgrade support library to 25 when gms is 11.2.0'() {
+        def compileLines = """\
+            compile 'com.google.android.gms:play-services-base:11.2.0'
+            compile 'com.android.support:appcompat-v7:23.0.1'
+        """
+
+        when:
+        def results = runGradleProject([
+            compileLines : compileLines
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            assert it.value.contains('com.google.android.gms:play-services-base:11.2.0\n')
+            assert it.value.contains('com.android.support:appcompat-v7:23.0.1 -> 25.1.0\n')
         }
     }
 }

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -746,4 +746,26 @@ class MainTest extends Specification {
             assert it.value.contains('com.android.support:appcompat-v7:23.0.1 -> 25.1.0\n')
         }
     }
+    // Run manually search for "Warning:".
+    //    If a support library class is listed
+    //      then the support library needs to be updated for the firebase / GMS version
+    def 'Find min-support for Firebase and GMS - build'() {
+        GradleTestTemplate.buildArgumentSets[GRADLE_OLDEST_VERSION] = [['transformClassesAndResourcesWithProguardForDebug', '--info']]
+        when:
+        // Keep as '+' for latest when checking in to this fails when Google changes requirements
+        def gms_version = '+'
+        def results = runGradleProject([
+            compileLines: """
+                compile 'com.google.android.gms:play-services-base:$gms_version'
+                compile 'com.google.android.gms:play-services-gcm:$gms_version'
+                compile 'com.google.android.gms:play-services-maps:$gms_version'
+                compile 'com.google.firebase:firebase-messaging:+'
+                compile 'com.android.support:appcompat-v7:22.0.0'
+            """,
+            skipGradleVersion: GRADLE_LATEST_VERSION
+        ])
+
+        then:
+        assert results // Assert success
+    }
 }


### PR DESCRIPTION
* This is the start of this plugin defining a min version for support based on gms version
* Google uses exact versions which is overly restrictive in it's POM files