### PR TITLE
Upgrades to firebase-messaging:17.0.0 when core is

### DIFF
--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -18,6 +18,9 @@ class GradleTestTemplate {
         minSdkVersion: 15
     ]
 
+    // Set to '--info' or '--stacktrace' to debug issues
+    static def GRADLE_LOG_LEVEL = null
+
     static def GRADLE_LATEST_VERSION = '4.8'
     static def GRADLE_OLDEST_VERSION = '2.14.1'
 
@@ -29,13 +32,13 @@ class GradleTestTemplate {
 
         buildArgumentSets = [
             (GRADLE_OLDEST_VERSION): [
-                ['dependencies', '--configuration', 'compile', '--info'],
-                ['dependencies', '--configuration', '_debugCompile', '--info']
+                ['dependencies', '--configuration', 'compile', GRADLE_LOG_LEVEL],
+                ['dependencies', '--configuration', '_debugCompile', GRADLE_LOG_LEVEL]
             ],
             (GRADLE_LATEST_VERSION): [
                 // compile does not work on it's own for tests since we use variant.compileConfiguration
-                ['dependencies', '--configuration', 'compile', '--info'],
-                ['dependencies', '--configuration', 'debugCompileClasspath', '--info'] //  '--stacktrace'
+                ['dependencies', '--configuration', 'compile', GRADLE_LOG_LEVEL],
+                ['dependencies', '--configuration', 'debugCompileClasspath', GRADLE_LOG_LEVEL] //  '--stacktrace'
             ]
         ]
     }
@@ -225,6 +228,8 @@ class GradleTestTemplate {
 //                    return
 //                currentParams['onesignalPluginId'] = "id 'com.onesignal.androidsdk.onesignal-gradle-plugin' apply false"
 //                currentParams['applyPlugins'] = "apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'"
+
+                buildArguments.removeAll([null])
 
                 def result =
                     GradleRunner.create()

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -68,6 +68,7 @@ class GradleTestTemplate {
            -dontwarn android.text.**
            -dontwarn android.service.**
            -dontwarn android.net.**
+           -dontwarn android.support.annotation.**
            
             # Had to omit the whole class. Keeps complaining about android.os.IBinder getBinder()
             #   Warning: android.support.v4.app.JobIntentService$JobServiceEngineImpl:
@@ -218,6 +219,12 @@ class GradleTestTemplate {
 
                 createSubProject(currentParams)
                 createProguardFile()
+
+                // Test running gradle plugin last on newest version of Gradle only
+//                if (gradleVersion.key == GRADLE_OLDEST_VERSION)
+//                    return
+//                currentParams['onesignalPluginId'] = "id 'com.onesignal.androidsdk.onesignal-gradle-plugin' apply false"
+//                currentParams['applyPlugins'] = "apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'"
 
                 def result =
                     GradleRunner.create()

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -403,7 +403,7 @@ class MainTest extends Specification {
 
         then:
         results.each {
-            assert it.value.contains('com.android.support:support-v4 overridden from \'+\' to \'27.+\'')
+            assert it.value.contains('com.android.support:support-v4:+ -> 27.1.1')
         }
     }
 
@@ -647,7 +647,6 @@ class MainTest extends Specification {
         then:
         assert results // Asserting existence and contains 1+ entries
         results.each {
-            assert it.value.contains("OneSignalProjectPlugin: com.google.android.gms:play-services-gcm overridden from '12.0.1' to '[15.0.0, 16.0.0)'")
             // The range should result in the highest available exact version in the range
             assert it.value.contains('com.google.android.gms:play-services-gcm:12.0.1 -> 15.0.1')
 
@@ -673,7 +672,6 @@ class MainTest extends Specification {
         then:
         assert results // Asserting existence and contains 1+ entries
         results.each {
-            assert it.value.contains("OneSignalProjectPlugin: com.google.firebase:firebase-messaging overridden from '[10.2.1, 12.1.0)' to '[15.0.0, 16.0.0)'")
             // The range should result in the highest available exact version in the range
             assert it.value.contains('com.google.firebase:firebase-messaging:[10.2.1, 12.1.0) -> 15.0.2')
 


### PR DESCRIPTION
* Upgrades to firebase-messaging:17.0.0 when using firebase-core:16.0.0 or newer
* This is required as firebase-messaging:15.X used to require firebase-core
* Without this upgrade runtime errors will result
* Resolves #53