### PR TITLE
Updated firebase-messaging when firebase-iid is

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -119,6 +119,7 @@ class GradleProjectPlugin implements Plugin<Project> {
         ]
     ]
 
+    // Similar to MODULE_DEPENDENCY_MINIMUMS but applied at the group level.
     static final def UPDATE_PARENT_ON_DEPENDENCY_UPGRADE = [
         (GROUP_ANDROID_SUPPORT): [
             '27.0.0': [
@@ -143,10 +144,27 @@ class GradleProjectPlugin implements Plugin<Project> {
         ]
     ]
 
+    // Summary: Map of modules with a map of versions if are at or higher then update the list of modules.
+    // Solves: Issue where a sub dependency of a module can be updated to a version that is incompatible
+    //         to a parent modules.
+    // Example: firebase-iid:16.2.0 and firebase-messaging:17.0.0 causes a runtime crash of
+    //    class not found. While scanning dependencies when we find firebase-iid:16.2.0
+    //    we will update firebase-messaging to 17.1.0 to fix this issue.
     static final Map<String, Map<String, Map<String, String>>> MODULE_DEPENDENCY_MINIMUMS = [
         'com.google.firebase:firebase-core': [
             '16.0.0': [
                 'com.google.firebase:firebase-messaging': '17.0.0'
+            ]
+        ],
+        'com.google.firebase:firebase-iid': [
+            '16.2.0': [
+                'com.google.firebase:firebase-messaging': '17.1.0'
+            ],
+            '17.0.0': [
+                'com.google.firebase:firebase-messaging': '17.3.0'
+            ],
+            '17.0.1': [
+                'com.google.firebase:firebase-messaging': '17.3.1'
             ]
         ]
     ]
@@ -162,7 +180,7 @@ class GradleProjectPlugin implements Plugin<Project> {
         }
     }
 
-    static Map<String, Object> versionModuleAligns = [:]
+    static Map<String, Object> versionModuleAligns
 
     static def versionGroupAligns
     static Project project
@@ -193,6 +211,7 @@ class GradleProjectPlugin implements Plugin<Project> {
         versionGroupAligns = InternalUtils.deepcopy(VERSION_GROUP_ALIGNS)
         copiedModules = [:]
         shownWarnings = [:]
+        versionModuleAligns = [:]
 
         generateMinModulesToTrackStatic()
 

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -25,7 +25,7 @@ class MainTest extends Specification {
 
         then:
         results.each {
-            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.10.1')
+            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.10.2')
         }
     }
 
@@ -728,6 +728,30 @@ class MainTest extends Specification {
         assert results // Asserting existence and contains 1+ entries
         results.each {
             assert it.value.contains('com.google.firebase:firebase-messaging:15.0.2 -> 17.0.0')
+        }
+    }
+
+    // TODO:*: Future, should step through all versions to discover limits automatically
+    // This also covers case when firebase-core:16.0.4, as it depends on firebase-iid:17.0.3
+    def 'when firebase-core:16.0.4 and firebase-messaging:15.0.2 upgrade to firebase-messaging:17.3.1'() {
+        def compileLines = """\
+            compile 'com.google.firebase:firebase-messaging:15.0.2'
+            compile 'com.google.firebase:firebase-iid:17.0.3'
+        """
+
+        // Can enable the following to do a build with proguard to find minimum versions
+        // GradleTestTemplate.buildArgumentSets[GRADLE_LATEST_VERSION] = [['build']] // , '--info']]
+
+        when:
+        def results = runGradleProject([
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            compileLines : compileLines
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            assert it.value.contains('com.google.firebase:firebase-messaging:15.0.2 -> 17.3.1')
         }
     }
 


### PR DESCRIPTION
* Updating firebase-iid to to new of a version can cause runtime crashes with firebase-messaging
* Added a list of minimum versions firebase-messaging needs when updating to certain versions of firebase-iid
* Fixes #69