### PR TITLE
Fixes Assuming max safe default of '28.+' for ...

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -90,7 +90,8 @@ class GradleProjectPlugin implements Plugin<Project> {
                 24: '25.+',
                 25: '25.+',
                 26: '27.+',
-                27: '27.+'
+                27: '27.+',
+                28: '28.+'
             ]
         ],
 


### PR DESCRIPTION
* Add compileSdkVersionMax entry for Android support 28
* Tested that Android Support 28 does not work with compileSdkVersion so kept this at 27.+