### PR TITLE
Upgrade firebase dependencies with play-servcies

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -167,6 +167,16 @@ class GradleProjectPlugin implements Plugin<Project> {
             '17.0.1': [
                 'com.google.firebase:firebase-messaging': '17.3.1'
             ]
+        ],
+        'com.google.android.gms:play-services-measurement-base': [
+            '15.0.4': [
+                'com.google.firebase:firebase-analytics': '16.0.0'
+            ]
+        ],
+        'com.google.android.gms:play-services-basement': [
+            '16.0.1': [
+                'com.google.firebase:firebase-messaging': '17.3.3'
+            ]
         ]
     ]
 
@@ -477,11 +487,12 @@ class GradleProjectPlugin implements Plugin<Project> {
         versionOverride['version'] = newMaxVersion
     }
 
-    static void overrideVersion(DependencyResolveDetails details, String resolvedVersion) {
+    static void overrideVersion(DependencyResolveDetails details, String groupVersionOverride) {
         def group = details.requested.group
         def name = details.requested.name
         def version = details.requested.version
 
+        String resolvedVersion = null
         def moduleOverride = versionModuleAligns["$group:$name"]
 
         // 1. Special Google rule if going from pre-15's non-semantic versions to 15+'s semantic versions
@@ -515,6 +526,8 @@ class GradleProjectPlugin implements Plugin<Project> {
                 resolvedVersion
             )
         }
+        else if (resolvedVersion == null)
+            resolvedVersion = groupVersionOverride
 
         // 3. Omit if no value
         if (resolvedVersion == null || resolvedVersion == NO_REF_VERSION)

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -751,7 +751,7 @@ class MainTest extends Specification {
         then:
         assert results // Asserting existence and contains 1+ entries
         results.each {
-            assert it.value.contains('com.google.firebase:firebase-messaging:15.0.2 -> 17.3.1')
+            assert it.value.contains('com.google.firebase:firebase-messaging:15.0.2 -> 17.3.3')
         }
     }
 
@@ -794,6 +794,43 @@ class MainTest extends Specification {
         }
     }
 
+    def 'when play-services-measurement-base:15.0.4 upgrade to firebase-analytics:16.0.0'() {
+        def compileLines = """\
+            compile 'com.google.firebase:firebase-analytics:15.0.2'
+            compile 'com.google.android.gms:play-services-measurement-base:15.0.4'
+        """
+
+        when:
+        def results = runGradleProject([
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            compileLines : compileLines
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            assert it.value.contains('com.google.firebase:firebase-analytics:15.0.2 -> 16.0.0')
+        }
+    }
+
+    def 'when play-services-basement:16.0.1 upgrade to firebase-messaging:17.3.3'() {
+        def compileLines = """\
+            compile 'com.google.firebase:firebase-messaging:17.0.0'
+            compile 'com.google.android.gms:play-services-basement:16.0.1'
+        """
+
+        when:
+        def results = runGradleProject([
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            compileLines : compileLines
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            assert it.value.contains('com.google.firebase:firebase-messaging:17.0.0 -> 17.3.3')
+        }
+    }
 
     // Note: Slow 20 second test, this is doing a full build
     //   This is needed as we are making sure compile and runtime versions are not being miss aligned


### PR DESCRIPTION
* Updates firebase dependencies when play-servcies is upgraded
   - See map in code for the specific versions
* Fixed a case where group version could upgrade to a higher versions when it should not
* Fixes issue https://github.com/OneSignal/OneSignal-Android-SDK/issues/654