### PR TITLE
Omit version override on module transformation

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -92,6 +92,7 @@ class GradleProjectPlugin implements Plugin<Project> {
                 26: '27.+',
                 27: '27.+',
                 28: '28.+'
+                // There is no 29, AndroidX has taken it's place
             ]
         ],
 
@@ -465,7 +466,7 @@ class GradleProjectPlugin implements Plugin<Project> {
         if (!inGroupAlignList(details))
             return
 
-        String toVersion = finalAlignmentRules()[details.requested.group]['version']
+        String toVersion = finalAlignmentRules()[details.target.group]['version']
         overrideVersion(details, toVersion)
     }
 
@@ -510,9 +511,9 @@ class GradleProjectPlugin implements Plugin<Project> {
     }
 
     static void overrideVersion(DependencyResolveDetails details, String groupVersionOverride) {
-        def group = details.requested.group
-        def name = details.requested.name
-        def version = details.requested.version
+        def group = details.target.group
+        def name = details.target.name
+        def version = details.target.version
 
         String resolvedVersion = null
         def moduleOverride = versionModuleAligns["$group:$name"]
@@ -573,8 +574,8 @@ class GradleProjectPlugin implements Plugin<Project> {
     }
 
     static void logModuleOverride(DependencyResolveDetails details, String resolvedVersion) {
-        def modName = "${details.requested.group}:${details.requested.name}"
-        def versionsMsg = "'${details.requested.version}' to '${resolvedVersion}'"
+        def modName = "${details.target.group}:${details.target.name}"
+        def versionsMsg = "'${details.target.version}' to '${resolvedVersion}'"
         def msg = "${modName} overridden from ${versionsMsg}"
         project.logger.info("OneSignalProjectPlugin: ${msg}")
     }
@@ -595,7 +596,7 @@ class GradleProjectPlugin implements Plugin<Project> {
     }
 
     static boolean inGroupAlignList(DependencyResolveDetails details) {
-        inGroupAlignListFindByStrings(details.requested.group, details.requested.name)
+        inGroupAlignListFindByStrings(details.target.group, details.target.name)
     }
 
     // Compares two exact versions
@@ -699,7 +700,7 @@ class GradleProjectPlugin implements Plugin<Project> {
                 return
 
             // Needed for "Upgrade to compatible OneSignal SDK when using Android Support library rev 27" test
-            String curOverrideVersion = versionGroupAligns[details.requested.group]['version']
+            String curOverrideVersion = versionGroupAligns[details.target.group]['version']
             overrideVersion(details, curOverrideVersion)
         }
 

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -106,12 +106,21 @@ class GradleTestTemplate {
         '''.stripIndent()
     }
 
+    static def createGradlePropertiesFile(buildSections) {
+        def gradlePropertiesFile = testProjectDir.newFile("gradle.properties")
+        gradlePropertiesFile << """\
+            android.useAndroidX=${buildSections['android.useAndroidX'] ?: false}
+            android.enableJetifier=${buildSections['android.enableJetifier'] ?: false}
+        """.stripIndent()
+    }
+
     static void createBuildFile(buildSections) {
         testProjectDir = new TemporaryFolder()
         testProjectDir.create()
         testProjectDir.newFolder('src', 'main')
         createManifest('src/main')
         createGoogleServicesJson('')
+        createGradlePropertiesFile(buildSections)
 
         buildFileStr = """\
             buildscript {

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -294,6 +294,25 @@ class MainTest extends Specification {
         }
     }
 
+    def 'Works with Jetifier and picks correct version AndroidX version'() {
+        when:
+        def results = runGradleProject([
+            'android.useAndroidX': true,
+            'android.enableJetifier': true,
+            compileLines: """
+                implementation 'com.google.android.gms:play-services-ads:18.1.0'
+                implementation 'com.android.support:cardview-v7:[26.0.0, 27.2.0)'
+            """,
+            skipGradleVersion: GRADLE_OLDEST_VERSION
+        ])
+
+        then:
+        assert results // Assert success and contains 1+ entries
+        results.each {
+            assert it.value.contains('com.android.support:cardview-v7:[26.0.0, 27.2.0) -> androidx.cardview:cardview:1.0.0')
+        }
+    }
+
     def "Upgrade to compatible OneSignal SDK when using Android Support library rev 27"() {
         when:
         def results = runGradleProject([


### PR DESCRIPTION
* When reading DependencyResolveDetails use target instead of requested to check if we should override version
  - This fixes an issue where Jetifier would change the package group from com.android.support to androidx but this plugin would still override the version