### PR TITLE
Ignore Firebase Unity libraries

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -69,7 +69,10 @@ class GradleProjectPlugin implements Plugin<Project> {
 
         // ### Google Firebase library
         (GROUP_FIREBASE): [
-            version: NO_REF_VERSION
+            version: NO_REF_VERSION,
+            // Do not attempt to align Firebase's Unity libraries
+            // These wrapper libraries have their own version numbers that don't line up
+            omitModulesPostFix: '-unity',
         ],
 
         // ### Android Support Library
@@ -596,6 +599,10 @@ class GradleProjectPlugin implements Plugin<Project> {
         // Skip modules that should not align to other modules in the group
         def omitModules = versionOverride['omitModules']
         if (omitModules && omitModules.contains(name))
+            return false
+
+        def omitModulesPostFix = versionOverride['omitModulesPostFix']
+        if (omitModulesPostFix && name.endsWith(omitModulesPostFix))
             return false
 
         true

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -25,7 +25,7 @@ class MainTest extends Specification {
 
         then:
         results.each {
-            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.11.1')
+            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.11.2')
         }
     }
 
@@ -961,6 +961,27 @@ class MainTest extends Specification {
         assert results // Asserting existence and contains 1+ entries
         results.each {
             assert it.value.contains('com.google.firebase:firebase-messaging:17.0.0 -> 17.6.0')
+        }
+    }
+
+    def 'when firebase-app-unity and firebase-messaging'() {
+        when:
+        def results = runGradleProject([
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            compileLines : """\
+                implementation 'com.google.firebase:firebase-messaging:17.0.0'
+                implementation 'com.google.firebase:firebase-app-unity:6.2.2'
+            """,
+            preBuildClosure: {
+                GradleTestTemplate.createM2repository('com.google.firebase', 'firebase-app-unity', '6.2.2')
+            }
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            // Ensure we are not trying to update this unity library
+            assert it.value.contains('com.google.firebase:firebase-app-unity:6.2.2\n')
         }
     }
 


### PR DESCRIPTION
* Example such as com.google.firebase:firebase-messaging-unity:6.2.2
  - We need to omit as these wrapper library versions do not line up with Firebase's native ones