### PR TITLE
Gradle plugin-publish:0.11.0 required to release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.9.10'
+    id 'com.gradle.plugin-publish' version '0.11.0'
     id 'java-gradle-plugin'
 }
 


### PR DESCRIPTION
* Gradle no longer allows releasing with 0.9.10 due to security issue.