### PR TITLE
Add rule for firebase-common

### DIFF
--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -27,7 +27,7 @@ class MainTest extends Specification {
 
         then:
         results.each {
-            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.13.2')
+            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.14.0')
         }
     }
 

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -1023,6 +1023,25 @@ class MainTest extends Specification {
         }
     }
 
+    def 'when firebase-common:18.0.0 ensure firebase-iid:19.0.0 and a cascade firebase-messaging:18.0.0 update'() {
+        when:
+        def results = runGradleProject([
+            'android.useAndroidX': true,
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            compileLines: """
+                implementation 'com.google.firebase:firebase-messaging:[10.2.1, 17.3.99]'
+                implementation 'com.google.firebase:firebase-common:18.0.0'
+            """
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            assert it.value.contains('com.google.firebase:firebase-iid:18.0.0 -> 19.0.0')
+            assert it.value.contains('com.google.firebase:firebase-messaging:[10.2.1, 17.3.99] -> 18.0.0')
+        }
+    }
+
     def 'when firebase-app-unity and firebase-messaging'() {
         when:
         def results = runGradleProject([


### PR DESCRIPTION
* Specifically if upgrading to `firebase-common:18.0.0` then
`firebase-iid:19.0.0` or newer must be used.
* Also added cascading parent updating.
This was require to update firebase-messaging as the new
firebase-common rule would update firebase-iid from under it