### PR TITLE
Adding support for Gradle BOM

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -553,6 +553,12 @@ class GradleProjectPlugin implements Plugin<Project> {
         def name = details.target.name
         def version = details.target.version
 
+        // null means it was added the project without a version number and must be driven by a BOM such as firebase-bom
+        // This means we have / will see the same dependency with a version again from the BOM as a constraint,
+        //    which can be overridden.
+        if (!version)
+            return
+
         String resolvedVersion = null
         def moduleOverride = versionModuleAligns["$group:$name"]
 

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -825,6 +825,71 @@ class MainTest extends Specification {
         }
     }
 
+    def 'fcm 15 and crashlytics with firebase platform BOM'() {
+        when:
+        def results = runGradleProject([
+            'android.useAndroidX': true,
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            compileLines : """\
+                implementation platform('com.google.firebase:firebase-bom:25.4.1')
+                implementation 'com.google.firebase:firebase-messaging:15.0.0'
+                implementation 'com.google.firebase:firebase-crashlytics'
+            """
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            // 1. Ensure firebase-bom is allowed to upgrade firebase-messaging
+            assert it.value.contains('com.google.firebase:firebase-messaging:15.0.0 -> 20.2.0')
+            // 2. Ensure version from firebase-bom is used and we don't try to downgrade
+            assert it.value.contains('com.google.firebase:firebase-crashlytics -> 17.0.1')
+        }
+    }
+
+    def 'pre-15 firebase with firebase-bom platform 17 BOM'() {
+        when:
+        def results = runGradleProject([
+            'android.useAndroidX': true,
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            compileLines : """\
+                implementation platform('com.google.firebase:firebase-bom:17.0.0')
+                implementation 'com.google.firebase:firebase-messaging:12.0.0'
+            """
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            // 1. Ensure firebase-bom is allowed to upgrade firebase-messaging
+            assert it.value.contains('com.google.firebase:firebase-messaging:12.0.0 -> 17.5.0')
+            // 2. Ensures this sub dependency get force downgraded to 12.0.0
+            assert it.value.contains("com.google.firebase:firebase-measurement-connector:17.0.1${NEW_LINE}")
+        }
+    }
+
+    def 'fcm 15 and crashlytics with firebase enforcedPlatform BOM'() {
+        when:
+        def results = runGradleProject([
+            'android.useAndroidX': true,
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            compileLines : """\
+                implementation enforcedPlatform('com.google.firebase:firebase-bom:25.4.1')
+                implementation 'com.google.firebase:firebase-messaging:15.0.0'
+                implementation 'com.google.firebase:firebase-crashlytics'
+            """
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+        results.each {
+            // 1. Ensure firebase-bom is allowed to upgrade firebase-messaging
+            assert it.value.contains('com.google.firebase:firebase-messaging:15.0.0 -> 20.2.0')
+            // 2. Ensure version from firebase-bom is used and we don't try to downgrade
+            assert it.value.contains('com.google.firebase:firebase-crashlytics -> 17.0.1')
+        }
+    }
+
     def 'when firebase-core:16 and firebase-messaging:15.0.2 upgrade to firebase-messaging:17.0.0'() {
         def compileLines = """\
             compile 'com.google.firebase:firebase-messaging:15.0.2'


### PR DESCRIPTION
## Issue
See Issue #127 for a summary

## Summary of Changes
Since BOM files allow you to omit defining a version at all the requested version is `null`. At the apply override step we check the original version which when we see `null` we assumed the version was `0`. This means we force either an invalid version or downgrade when should not. We now skip by these `null` versions as the BOM inserts a constraint entry which is picked up the same `overrideVersion` flow and can apply it like a normal direct dependency.

---

Useful debugging commit - https://github.com/OneSignal/OneSignal-Gradle-Plugin/pull/128/commits/1333ef1f2347af0919f0e20887d46a74e0122a89
It was unneeded but if we ever need to omit BOMs from group alignment calculations see PR #129