### PR TITLE
Fixed Android Support Library downgrade to invalid "28" version

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -529,10 +529,10 @@ class GradleProjectPlugin implements Plugin<Project> {
             if (maxSupportVersion)
                 maxSupportVersion
             else
-                LAST_MAJOR_ANDROID_SUPPORT_VERSION
+                LAST_MAJOR_ANDROID_SUPPORT_VERSION + ".+"
         }
         else
-            LAST_MAJOR_ANDROID_SUPPORT_VERSION
+            LAST_MAJOR_ANDROID_SUPPORT_VERSION + ".+"
     }
 
     static void overrideVersion(DependencyResolveDetails details, String groupVersionOverride) {

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -22,7 +22,12 @@ class MainTest extends Specification {
         // 1.Ensure one or more results exist
         assert results
 
-        // 2. Run test specific asserts
+        // 2. Ensure we don't have any failures
+        results.each {
+            assert !it.value.contains('FAILED')
+        }
+
+        // 3. Run test specific asserts
         results.each {
             closure(it)
         }


### PR DESCRIPTION
* Added assert for "FAILED" which uncovered the issue by failing the following existing test
  * "Upgrade to compatible OneSignal SDK when targetSdkVersion is 29"
* cherry-picked commit from #135 which fixes the issue.

