### PR TITLE
Upgraded alignments  on firebase libraries

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -166,7 +166,8 @@ class GradleProjectPlugin implements Plugin<Project> {
         'com.google.firebase:firebase-core': [
             '16.0.0': [
                 'com.google.firebase:firebase-messaging': '17.0.0'
-            ]
+            ],
+            // Tested up to firebase-core:17.5.1
         ],
         'com.google.firebase:firebase-common': [
             // Tested firebase-common:17.1.0 back to firebase-iid:10.2.1
@@ -218,7 +219,11 @@ class GradleProjectPlugin implements Plugin<Project> {
             ],
             '20.1.5': [
                 'com.google.firebase:firebase-messaging': '20.1.4'
-            ]
+            ],
+            '20.2.2': [
+                'com.google.firebase:firebase-messaging': '20.2.2'
+            ],
+            // Tested up to firebase-iid:20.3.0
         ],
         'com.google.android.gms:play-services-measurement-base': [
             '15.0.4': [
@@ -231,7 +236,11 @@ class GradleProjectPlugin implements Plugin<Project> {
             ],
             '17.0.0': [
                 'com.google.android.gms:play-services-base': '17.0.0'
-            ]
+            ],
+            '17.1.0': [
+                'com.google.firebase:firebase-messaging': '19.0.0'
+            ],
+            // Tested up to play-services-basement:17.4.0
         ]
     ]
 

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -232,7 +232,8 @@ class GradleProjectPlugin implements Plugin<Project> {
         ],
         'com.google.android.gms:play-services-basement': [
             '16.0.1': [
-                'com.google.firebase:firebase-messaging': '17.3.3'
+                'com.google.firebase:firebase-messaging': '17.3.3',
+                'com.google.android.gms:play-services-base': '16.0.1',
             ],
             '17.0.0': [
                 'com.google.android.gms:play-services-base': '17.0.0'


### PR DESCRIPTION
* `firebase-iid:20.2.2` sets a min version of `firebase-messaging:20.2.2`
* `play-services-basement:17.1.0` sets a min version of `firebase-messaging:19.0.0`
* `play-services-base:16.0.1` sets a min version of `play-services-basement:16.0.1`
   - Fixes #132
* These version were observed by ensuring no proguard errors of missing class / method definitions

