### PR TITLE
Updated version align rules for all Google modules 2020-12-05

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -167,14 +167,14 @@ class GradleProjectPlugin implements Plugin<Project> {
             '16.0.0': [
                 'com.google.firebase:firebase-messaging': '17.0.0'
             ],
-            // Tested up to firebase-core:17.5.1
+            // Tested up to firebase-core:18.0.0
         ],
         'com.google.firebase:firebase-common': [
             // Tested firebase-common:17.1.0 back to firebase-iid:10.2.1
             '18.0.0': [
                 'com.google.firebase:firebase-iid': '19.0.0'
             ]
-            // Tested up to firebase-common:19.3.0
+            // Tested up to firebase-common:19.4.0
         ],
         'com.google.firebase:firebase-iid': [
             '16.2.0': [
@@ -231,7 +231,12 @@ class GradleProjectPlugin implements Plugin<Project> {
         'com.google.android.gms:play-services-measurement-base': [
             '15.0.4': [
                 'com.google.firebase:firebase-analytics': '16.0.0'
-            ]
+            ],
+            // NOTE: Versions in-between untested
+            '18.0.0': [
+                'com.google.firebase:firebase-analytics': '18.0.0'
+            ],
+            // Tested up to play-services-measurement-base:18.0.0
         ],
         'com.google.android.gms:play-services-basement': [
             '16.0.1': [
@@ -244,7 +249,7 @@ class GradleProjectPlugin implements Plugin<Project> {
             '17.1.0': [
                 'com.google.firebase:firebase-messaging': '19.0.0'
             ],
-            // Tested up to play-services-basement:17.4.0
+            // Tested up to play-services-basement:17.5.0
         ]
     ]
 

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -223,7 +223,10 @@ class GradleProjectPlugin implements Plugin<Project> {
             '20.2.2': [
                 'com.google.firebase:firebase-messaging': '20.2.2'
             ],
-            // Tested up to firebase-iid:20.3.0
+            '21.0.0': [
+                'com.google.firebase:firebase-messaging': '21.0.0'
+            ],
+            // Tested up to firebase-iid:21.0.0
         ],
         'com.google.android.gms:play-services-measurement-base': [
             '15.0.4': [


### PR DESCRIPTION
_Recommend reviewing commit-by-commit_

### Updated latest required iid / messaging 21.0.0
* Confirmed using `firebase-iid:21.0.0` requires bumping to `firebase-messaging:21.0.0` and added rule for this.

### Checked and Updated all Google module min versions
* Confirmed using `play-services-measurement-base` requires bumping to `firebase-analytics:18.0.0` and added rule for this.
* Checked all other Module rules for Google libraries and updated comments


NOTE: Based off branch `upgrade/apg_4.1.1_and_gradle_6.7.1`, merge that one in first then rebase this one on `master` before merging.