### PR TITLE
Fix disableVersionCheck when GoogleServicesPlugin is applied with afterEvaluate 

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -303,7 +303,7 @@ class GradleProjectPlugin implements Plugin<Project> {
     // At fundamental level this OneSignal plugin and the gms version checks are solving the same problem
     // Disabling the version check part of the gms plugin with their flag
     static void disableGMSVersionChecks() {
-        project.afterEvaluate {
+        project.plugins.withType(Plugin) {
             def googleServices = project.extensions.findByName('googleServices')
             if (googleServices)
                 googleServices.disableVersionCheck = true

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -304,9 +304,7 @@ class GradleProjectPlugin implements Plugin<Project> {
     // Disabling the version check part of the gms plugin with their flag
     static void disableGMSVersionChecks() {
         project.plugins.withType(Plugin) {
-            def googleServices = project.extensions.findByName('googleServices')
-            if (googleServices)
-                googleServices.disableVersionCheck = true
+            project.extensions.findByName('googleServices')?.disableVersionCheck = true
         }
     }
 

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -803,6 +803,29 @@ class MainTest extends Specification {
         }
     }
 
+    // Same as the test above but handles the afterEvaluate case. See a plugin that does this below
+    // https://github.com/dpa99c/cordova-plugin-firebasex/blob/11.0.3/src/android/build.gradle#L43
+    def 'can disable "Google Services Gradle Plugin" version checks with disableVersionCheck - even if added in afterEvaluate'() {
+        def compileLines = """\
+            compile 'com.onesignal:OneSignal:3.15.6'
+            compile 'com.google.android.gms:play-services-base:17.3.0'
+        """
+
+        when:
+        def results = runGradleProject([
+                skipGradleVersion: GRADLE_OLDEST_VERSION,
+                'android.useAndroidX': true,
+                'android.enableJetifier': true,
+                buildscriptDependencies: "classpath 'com.google.gms:google-services:4.3.4'",
+                applyPlugins: "afterEvaluate { apply plugin: 'com.google.gms.google-services' }",
+                compileLines : compileLines,
+        ])
+
+        then:
+        assertResults(results) {
+        }
+    }
+
     def 'gms 15 - Support for 12 and 15 version'() {
         def compileLines = """\
             compile 'com.google.android.gms:play-services-gcm:12.0.1'

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -758,6 +758,31 @@ class MainTest extends Specification {
         assert results // Asserting existence and contains 1+ entries
     }
 
+    def 'can disable "Google Services Gradle Plugin" version checks with disableVersionCheck'() {
+        // com.onesignal:OneSignal:3.15.6' defines a version range of play-services-base@[10.2.1, 16.1.99]
+        // 17.3.0 is outside of that but this is ok, since enableJetifier is enabled in this case.
+        // However "Google Services Gradle Plugin" thinks there is a version out of range and fails the build
+        // We are ensuring this plugin sets disableVersionCheck correctly to disable it
+        def compileLines = """\
+            compile 'com.onesignal:OneSignal:3.15.6'
+            compile 'com.google.android.gms:play-services-base:17.3.0'
+        """
+
+        when:
+        def results = runGradleProject([
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            'android.useAndroidX': true,
+            'android.enableJetifier': true,
+            buildscriptDependencies: "classpath 'com.google.gms:google-services:4.3.4'",
+            applyPlugins: "apply plugin: 'com.google.gms.google-services'",
+            compileLines : compileLines
+        ])
+
+        then:
+        assertResults(results) {
+        }
+    }
+
     def 'firebase 15 - keep mixed minor versions'() {
         def compileLines = """\
             compile 'com.google.firebase:firebase-ads:15.0.0'


### PR DESCRIPTION
## Issue
* `disableGMSVersionChecks` doesn't work in a case which this PR addresses.
```gradle
    afterEvaluate {
        rootProject.subprojects {
            if (name == "app") {
                if (!plugins.hasPlugin('com.google.gms.google-services')) {
                    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
                }
            }
        }
    }
 ```

## Fixes
* This resolves the version range issue noted in https://github.com/OneSignal/OneSignal-Cordova-SDK/issues/672
* Possibly other github issues

## Reviewing
Recommend reviewing commit by commit