### PR TITLE
Fix AGP version detection when used in an "apply from:" file

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -357,6 +357,10 @@ class GradleProjectPlugin implements Plugin<Project> {
         if (pluginVersion)
             return pluginVersion
 
+        pluginVersion = getAGPFromResolvedConfiguration()
+        if (pluginVersion)
+            return pluginVersion
+
         getAGPVersionByGradleVersion()
     }
 
@@ -389,6 +393,20 @@ class GradleProjectPlugin implements Plugin<Project> {
                 project.logger.warn("Error reading 'META-INF/MANIFEST.MF' for '$plugin'")
         }
         null
+    }
+
+    // Gets the AGP version when this plugin is applied from an "apply from:" file
+    static String getAGPFromResolvedConfiguration() {
+        if (!project)
+            return null
+        String agpVersion = null
+        project.buildscript.configurations.classpath.resolvedConfiguration.firstLevelModuleDependencies.each {
+            if (it.moduleGroup == 'com.android.tools.build' && it.moduleName == 'gradle') {
+                agpVersion = it.moduleVersion
+                return
+            }
+        }
+        return agpVersion;
     }
 
     // Only use as a fallback, use getAGPVersionFromAndroidClass() instead if it's available

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -336,11 +336,12 @@ class GradleProjectPlugin implements Plugin<Project> {
         }
     }
 
+    static final def WARNING_MSG_COULD_NOT_GET_AGP_VERSION = 'OneSignal Warning: Could not get AGP plugin version'
     static boolean isAGPVersionOlderThan(Plugin plugin, String version) {
         def agpVersion = getAGPVersion(plugin)
         if (!agpVersion) {
             if (project)
-                project.logger.warn('OneSignal Warning: Could not get AGP plugin version')
+                project.logger.warn(WARNING_MSG_COULD_NOT_GET_AGP_VERSION)
             return false
         }
 

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -139,6 +139,15 @@ class GradleTestTemplate {
         """
     }
 
+    static final def APPLY_FROM_FILE_NAME = 'applyFromFile.gradle'
+    static void createApplyFromFile(buildSections) {
+        if (buildSections['applyFromFileContents'] == null)
+            return
+
+        final gradleFile = testProjectDir.newFile(APPLY_FROM_FILE_NAME)
+        gradleFile << buildSections['applyFromFileContents']
+    }
+
     static void createBuildFile(buildSections) {
         testProjectDir = new TemporaryFolder()
         testProjectDir.create()
@@ -179,6 +188,12 @@ class GradleTestTemplate {
 
             apply plugin: 'com.android.application'
             ${buildSections['applyPlugins']}
+            ${
+                if (buildSections['applyFromFileContents'])
+                    "apply from: '${APPLY_FROM_FILE_NAME}'"
+                else
+                    ''
+            }
 
             android {
                 compileSdkVersion ${buildSections['compileSdkVersion']}
@@ -284,6 +299,7 @@ class GradleTestTemplate {
                 buildFile << buildFileStr
 
                 createSubProject(currentParams)
+                createApplyFromFile(currentParams)
                 createProguardFile()
 
                 // Uncomment to test with only the latest version of Gradle

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -783,6 +783,23 @@ class MainTest extends Specification {
         }
     }
 
+    // Makes sure we can detect the AGP version if it was applied from "apply from: 'filename.gradle'" file
+    // This requires a special edge case as "apply from:" doesn't not inherit the classpath from the host file.
+    // See https://github.com/gradle/gradle/issues/4007 for more details.
+    def 'can detect AGP version within an apply from .gradle file'() {
+        when:
+        def results = runGradleProject([
+            skipGradleVersion: GRADLE_OLDEST_VERSION,
+            onesignalPluginId: "id 'com.onesignal.androidsdk.onesignal-gradle-plugin' apply false",
+            applyFromFileContents: "apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'"
+        ])
+
+        then:
+        assertResults(results) {
+            assert !it.value.contains(GradleProjectPlugin.WARNING_MSG_COULD_NOT_GET_AGP_VERSION)
+        }
+    }
+
     def 'firebase 15 - keep mixed minor versions'() {
         def compileLines = """\
             compile 'com.google.firebase:firebase-ads:15.0.0'


### PR DESCRIPTION
## Issue
"OneSignal Warning: Could not get AGP plugin version" warning still prints if this plugin is applied from an "apply from:" file.
   - This is the default way Cordova adds gradle scripts from plugins in the `app/build.gradle`.

"apply from:" requires a special case handling as the in an "apply from:" file the hosting file's `classpath` is not inherited. See https://github.com/gradle/gradle/issues/4007 for more details.

## Fix
`project.buildscript` can be inspected per this answer and this strategy was used in this PR:
https://stackoverflow.com/a/18119304/1244574

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-gradle-plugin/149)
<!-- Reviewable:end -->
