### PR TITLE
Remove .properties file as this is generated by Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,11 +82,6 @@ test {
     }
 }
 
-processResources {
-    // Required by Gradle 7
-    duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
-}
-
 // Build for Local Testing
 publishing {
     repositories {

--- a/src/main/resources/META-INF/gradle-plugins/com.onesignal.androidsdk.onesignal-gradle-plugin.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.onesignal.androidsdk.onesignal-gradle-plugin.properties
@@ -1,1 +1,0 @@
-implementation-class=com.onesignal.androidsdk.GradleProjectPlugin


### PR DESCRIPTION
Removed .properties file as this is generated by Gradle
* In-addition also removed duplicatesStrategy as this is no longer needed
as this was the only duplicated file being generated.
   - I recommend avoiding adding a duplicatesStrategy rule back in the
   future as it can hide issues and introduces complexity

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-gradle-plugin/158)
<!-- Reviewable:end -->
