### PR TITLE
Fix publish group issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.11.0'
+    id 'com.gradle.plugin-publish' version '0.15.0'
     id 'maven-publish'
     id 'java-gradle-plugin'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 }
 
 
-group = 'com.onesignal'
+group = 'gradle.plugin.com.onesignal'
 version = '0.13.0'
 description 'OneSignal Gradle Plugin'
 // Run to upload a new version to the Gradle Plugin Portal


### PR DESCRIPTION
Prefix group with "gradle.plugin"
* Gradle used to automatically prefix the group id with "gradle.plugin"
but in the 0.13.0 release this was no longer happening, possibility
due to upgrading to Gradle 7.
* This group change caused an issue where the Gradle Plugin Portal
thought this plugin was being moved to a different group which would
affect the classpath and requires approval. However this is a breaking
change we don't want so we have to now pre-fix it ourselves.
* See the following issue for more context on why this is required now.
   - gradle/plugin-portal-requests#103 (comment)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-gradle-plugin/159)
<!-- Reviewable:end -->
