### PR TITLE
0.13.2 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ buildscript {
     dependencies {
         // ...
         // OneSignal-Gradle-Plugin
-        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.13.0, 0.99.99]'
+        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.13.2, 0.99.99]'
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
 
 group = 'gradle.plugin.com.onesignal'
-version = '0.13.0'
+version = '0.13.2'
 description 'OneSignal Gradle Plugin'
 // Run to upload a new version to the Gradle Plugin Portal
 // ./gradlew publishPlugins
@@ -98,6 +98,6 @@ publishing {
 //      maven { url uri('../../repo') }
 // 3. Update '../../repo' from above to your correct relative path
 // 4. Add to buildscript -> dependencies
-//      classpath 'com.onesignal:onesignal-gradle-plugin:[0.13.0, 0.99.99]'
+//      classpath 'com.onesignal:onesignal-gradle-plugin:[0.13.2, 0.99.99]'
 // 5. To your app/build.gradle add
 //      apply plugin: com.onesignal.androidsdk.GradleProjectPlugin

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -277,7 +277,7 @@ class GradleProjectPlugin implements Plugin<Project> {
     @Override
     void apply(Project inProject) {
         project = inProject
-        project.logger.info('Initializing OneSignal-Gradle-Plugin 0.13.0')
+        project.logger.info('Initializing OneSignal-Gradle-Plugin 0.13.2')
 
         hasFullPlayServices = false
         gradleV2PostAGPApplyFallback = false


### PR DESCRIPTION
## Description
Version bumps for the 0.13.0 release.

## 0.13.2 Already shipped
0.13.2 is already live before this PR was created as it was the only way to confirm the changes in #159 fixed the publishing issue. 

## What happened to versions 0.13.0 & 0.13.1?
These were published under the wrong group id due an issue with the Gradle 7 upgrade process. 0.13.2 is the first 0.13.x version available but code was it is no different than the tagged 0.13.0 version.

### Reference
See #159 for more details on the group issue.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-gradle-plugin/160)
<!-- Reviewable:end -->
