### PR TITLE
Set published min JVM version to 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,15 @@ configurations.all {
     it.resolutionStrategy.activateDependencyLocking()
 }
 
+// NOTE: Take caution when updating targetCompatibility,
+//       it will become minimum required JVM version for projects consuming this plugin.
+//       This value is mapped to "org.gradle.jvm.version" published in the .module file.
+//       Run "./gradlew outgoingVariants --variant runtimeElements" to confirm the version
+compileJava {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
+
 dependencies {
     implementation gradleApi()
     implementation localGroovy()


### PR DESCRIPTION
* Fixes issue where required JVM was set to 11 from 0.13.2
  - Most likely com.gradle.plugin-publish:0.15.0 introduced the .module
  file. This defines a min JVM version which happens to default to 11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-gradle-plugin/163)
<!-- Reviewable:end -->
