### PR TITLE
Set jvm version for compileGroovy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ compileJava {
     targetCompatibility = '1.8'
 }
 
+compileGroovy {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}
+
 dependencies {
     implementation gradleApi()
     implementation localGroovy()


### PR DESCRIPTION
* Groovy does not automatically use the compileJava settings so we need
to define compileGroovy.
* Also defining as Java 1.8 so when a project consuming this plugin
it can run it with getting a "class file version" error.

This will fix errors such as
```
* What went wrong:
A problem occurred evaluating project ':app'.
> com/onesignal/androidsdk/GradleProjectPlugin has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

## Tests
### Manual
Ran `./gradle build` on an Android project with a local build of this plugin with Java 8 to reproduce the issue. Then rebuilt with this new setting to ensure this resolved the issue. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-gradle-plugin/166)
<!-- Reviewable:end -->
