### PR TITLE
Bump version to fix 3.x.x OneSignal test

### DIFF
--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -31,7 +31,7 @@ class MainTest extends Specification {
 
         then:
         assertResults(results) {
-            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.16.0')
+            assert it.value.contains('com.onesignal:OneSignal:[3.8.3, 3.99.99] -> 3.16.1')
         }
     }
 


### PR DESCRIPTION
## Description
This breaks every 3.x.x release. Only bumping instead of fixing the root issue as the chance of another 3.x.x release is low.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-gradle-plugin/181)
<!-- Reviewable:end -->
