### PR TITLE
Downgrade work-runtime if needed

### DIFF
--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -615,8 +615,12 @@ class GradleProjectPlugin implements Plugin<Project> {
         versionOverride['version'] = newMaxVersion
     }
 
+    static int getCompileSdkVersion() {
+        (project.android.compileSdkVersion as String).split('-')[1].toInteger()
+    }
+
     static String maxAndroidSupportVersion(Map<Integer, String> maxSupportVersionObj) {
-        def compileSdkVersion = (project.android.compileSdkVersion as String).split('-')[1].toInteger()
+        def compileSdkVersion = getCompileSdkVersion()
         if (compileSdkVersion <= LAST_MAJOR_ANDROID_SUPPORT_VERSION) {
             String maxSupportVersion = maxSupportVersionObj[compileSdkVersion]
             if (maxSupportVersion)

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -53,6 +53,7 @@ class GradleProjectPlugin implements Plugin<Project> {
 
     static final String GROUP_GMS = 'com.google.android.gms'
     static final String GROUP_ANDROID_SUPPORT = 'com.android.support'
+    static final String GROUP_ANDROIDX = 'androidx.work'
     static final String GROUP_FIREBASE = 'com.google.firebase'
     static final String GROUP_ONESIGNAL = 'com.onesignal'
 
@@ -101,7 +102,19 @@ class GradleProjectPlugin implements Plugin<Project> {
         // Exists only for UPDATE_PARENT_ON_DEPENDENCY_UPGRADE
         (GROUP_ONESIGNAL): [
             version: NO_REF_VERSION
-        ]
+        ],
+
+        // Exists only for MODULE_DEPENDENCY_MAX_ANDROID_COMPILE_SDK
+        (GROUP_ANDROIDX): [
+            version: NO_REF_VERSION
+        ],
+    ]
+
+    // Sets an upper limit for specific modules based on the compileSdkVersion
+    static final Map<String, Map<Integer, String>> MODULE_DEPENDENCY_MAX_ANDROID_COMPILE_SDK = [
+        'androidx.work:work-runtime': [
+            30: '2.6.+',
+        ],
     ]
 
 
@@ -941,8 +954,19 @@ class GradleProjectPlugin implements Plugin<Project> {
             }
         }
 
+        updateVersionModuleAlignsForCompileSdkVersion(inputModule)
+
         if (group == GROUP_GMS && module == 'play-services')
             hasFullPlayServices = true
+    }
+
+    static void updateVersionModuleAlignsForCompileSdkVersion(String module) {
+        def compileVersion = getCompileSdkVersion()
+        MODULE_DEPENDENCY_MAX_ANDROID_COMPILE_SDK[module].each {maxSdkVersion , versionMax ->
+            if (compileVersion <= maxSdkVersion) {
+                versionModuleAligns[module] = [version: versionMax]
+            }
+        }
     }
 
     static void updateVersionModuleAlignsKey(String groupAndModule, String version) {

--- a/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
+++ b/src/main/groovy/com/onesignal/androidsdk/GradleProjectPlugin.groovy
@@ -113,7 +113,7 @@ class GradleProjectPlugin implements Plugin<Project> {
     // Sets an upper limit for specific modules based on the compileSdkVersion
     static final Map<String, Map<Integer, String>> MODULE_DEPENDENCY_MAX_ANDROID_COMPILE_SDK = [
         'androidx.work:work-runtime': [
-            30: '2.6.+',
+            30: '[2.0.0, 2.6.99]',
         ],
     ]
 

--- a/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/GradleTestTemplate.groovy
@@ -13,7 +13,7 @@ class GradleTestTemplate {
     static def buildArgumentSets = [:]
 
     static def defaultBuildParams = [
-        compileSdkVersion: 30,
+        compileSdkVersion: 31,
         targetSdkVersion: 30,
         minSdkVersion: 16
     ]
@@ -162,6 +162,7 @@ class GradleTestTemplate {
             buildscript {
                 repositories {
                     maven { url 'https://maven.google.com' }
+                    mavenCentral()
                     jcenter()
                 }
                 dependencies {
@@ -184,6 +185,7 @@ class GradleTestTemplate {
                     maven { url 'https://maven.google.com' }
                     // Local maven repo to test local libaries; such as firebase-app-unity
                     maven { url(uri('m2repository')) }
+                    mavenCentral()
                     jcenter()
                 }
             }

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -1274,4 +1274,35 @@ class MainTest extends Specification {
         then:
         assert results // Asserting existence and contains 1+ entries
     }
+
+    // AGP task checkDebugAarMetadata has a build rule that checks for compileSdkVersion 31
+    // via a minCompileSdk property defined in the aar-metadata.properties in the work-runtime-2.7.0.aar
+    def runGradleProjectForCompileSdkVersion30WithWorkRuntime2_7_0() {
+        runGradleProject([
+            'android.useAndroidX': true,
+            compileSdkVersion: 30,
+            compileLines : "implementation 'androidx.work:work-runtime:[2.0.0, 2.7.0]'",
+            skipGradleVersion : GRADLE_OLDEST_VERSION,
+        ])
+    }
+
+    def 'compileSdkVersion 30 with work-runtime:2.7.0, passes checkDebugAarMetadata'() {
+        GradleTestTemplate.buildArgumentSets[GRADLE_LATEST_VERSION] = [['checkDebugAarMetadata']]
+
+        when:
+        def results = runGradleProjectForCompileSdkVersion30WithWorkRuntime2_7_0()
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+    }
+
+    def 'compileSdkVersion 30 with work-runtime:2.7.0, downgrades to 2.6.0'() {
+        when:
+        def results = runGradleProjectForCompileSdkVersion30WithWorkRuntime2_7_0()
+
+        then:
+        assertResults(results) {
+            assert it.value.contains('androidx.work:work-runtime:[2.0.0, 2.7.0] -> 2.6.0')
+        }
+    }
 }

--- a/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
+++ b/src/test/groovy/com/onesignal/androidsdk/MainTest.groovy
@@ -1305,4 +1305,37 @@ class MainTest extends Specification {
             assert it.value.contains('androidx.work:work-runtime:[2.0.0, 2.7.0] -> 2.6.0')
         }
     }
+
+    def 'compileSdkVersion 30 with onesignal:4.6.2, passes checkDebugAarMetadata'() {
+        GradleTestTemplate.buildArgumentSets[GRADLE_LATEST_VERSION] = [['checkDebugAarMetadata']]
+
+        when:
+        def results = runGradleProject([
+            'android.useAndroidX': true,
+            compileSdkVersion: 30,
+            compileLines : "implementation 'com.onesignal:OneSignal:4.6.2'",
+            skipGradleVersion : GRADLE_OLDEST_VERSION,
+        ])
+
+        then:
+        assert results // Asserting existence and contains 1+ entries
+    }
+
+    def 'compileSdkVersion 30 with onesignal:4.6.2 & work-runtime:2.4.0 '() {
+        when:
+        def results = runGradleProject([
+            'android.useAndroidX': true,
+            compileSdkVersion: 30,
+            compileLines : '''
+                implementation 'com.onesignal:OneSignal:4.6.2'
+                implementation 'androidx.work:work-runtime:2.4.0'
+            ''',
+            skipGradleVersion : GRADLE_OLDEST_VERSION,
+        ])
+
+        then:
+        assertResults(results) {
+            assert it.value.contains('androidx.work:work-runtime:[2.1.0, 2.7.99] -> 2.4.0')
+        }
+    }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Fixes tasks `:app:checkDebugAarMetadata` and `checkReleaseAarMetadata` failing at build time when a project has `work-runtime:2.7.0` (OneSignal-Android-SDK 4.6.2 uses this) and `compileSdkVersion 30` or older.

## What is the build error output
```
Execution failed for task ':app:checkDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > The minCompileSdk (31) specified in a
     dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
     is greater than this module's compileSdkVersion (android-30).
     Dependency: androidx.work:work-runtime:2.7.0.
     AAR metadata file: /Users/myusername/.gradle/caches/transforms-3/ac32b6abd74d5ceefc471e061744b632/transformed/work-runtime-2.7.0/META-INF/com/android/build/gradle/aar-metadata.properties.
```

### Scope
Only affects app projects that contain `work-runtime`. Whether that is directly or indirectly through a dependency.

### How was this implemented?
By checking for the app project's `compileSdkVersion` and defining a max version of  `2.6.+` for `work-runtime` if `compileSdkVersion` is 30 or less.

### Issues this fixes
* resolves https://github.com/OneSignal/react-native-onesignal/issues/1318
* resolves https://github.com/OneSignal/OneSignal-Cordova-SDK/issues/752

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-gradle-plugin/182)
<!-- Reviewable:end -->
